### PR TITLE
Export a `subscribe` method that returns a TC39 Subscription

### DIFF
--- a/quote-selection.js
+++ b/quote-selection.js
@@ -5,6 +5,19 @@ import selectionToMarkdown from './markdown-parsing'
 const containers = new WeakMap()
 let installed = 0
 
+type Subscription = {|
+  unsubscribe: () => void
+|}
+
+export function subscribe(container: Element): Subscription {
+  install(container)
+  return {
+    unsubscribe: () => {
+      uninstall(container)
+    }
+  }
+}
+
 export function install(container: Element) {
   installed += containers.has(container) ? 0 : 1
   containers.set(container, 1)

--- a/test/test.js
+++ b/test/test.js
@@ -18,6 +18,7 @@ function quote() {
 
 describe('quote-selection', function() {
   describe('with quotable selection', function() {
+    let subscription
     beforeEach(function() {
       document.body.innerHTML = `
         <p id="not-quotable">Not quotable text</p>
@@ -31,12 +32,12 @@ describe('quote-selection', function() {
         </div>
       `
       quoteSelection.install(document.querySelector('[data-quote]'))
-      quoteSelection.install(document.querySelector('[data-nested-quote]'))
+      subscription = quoteSelection.subscribe(document.querySelector('[data-nested-quote]'))
     })
 
     afterEach(function() {
       quoteSelection.uninstall(document.querySelector('[data-quote]'))
-      quoteSelection.uninstall(document.querySelector('[data-nested-quote]'))
+      subscription.unsubscribe()
       document.body.innerHTML = ''
     })
 


### PR DESCRIPTION
Usage:

```js
import {subscribe} from '@github/quote-selection'
import {observe} from 'selector-observer'

observe('.js-quote-selection-container', {subscribe})
```