### PR TITLE
Improve markdown quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,22 @@ $ npm install @github/quote-selection
 </div>
 ```
 
+#### Quote as Markdown
+
+An optional feature to translate quoted content into Markdown format is available via the `data-quote-markdown` attribute:
+
+```html
+<div data-quote-region data-quote-markdown=".comment-body">
+  <div class="comment-body">
+    <p>Text to quote</p>
+  </div>
+  <div class="comment-body">
+    <p>Some other text</p>
+  </div>
+  <textarea></textarea>
+</div>
+```
+
 ### JS
 
 ```js

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ An optional feature to translate quoted content into Markdown format is availabl
 </div>
 ```
 
-When selected, the text within the first `.comment-body` element with get quoted as:
+When selected, the text within the first `.comment-body` element will get quoted as:
 
 ```
 > ## **Formatted** text _to quote_

--- a/README.md
+++ b/README.md
@@ -26,13 +26,25 @@ An optional feature to translate quoted content into Markdown format is availabl
 ```html
 <div data-quote-region data-quote-markdown=".comment-body">
   <div class="comment-body">
-    <p>Text to quote</p>
+    <h2><strong>Formatted</strong> text <em>to quote</em></h2>
+    <p>
+      Preserves <code>inline code</code> and
+      <a href="https://guides.github.com/features/mastering-markdown/">other features</a>.
+    </p>
   </div>
   <div class="comment-body">
     <p>Some other text</p>
   </div>
   <textarea></textarea>
 </div>
+```
+
+When selected, the text within the first `.comment-body` element with get quoted as:
+
+```
+> ## **Formatted** text _to quote_
+>
+> Preserves `inline code` and [other features](https://guides.github.com/features/mastering-markdown/).
 ```
 
 ### JS

--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -113,21 +113,27 @@ const filters: {[key: string]: (HTMLElement) => string | HTMLElement} = {
 
     if (!list) throw new Error()
 
+    let bullet = ''
     if (!nestedListExclusive(el)) {
       switch (list.nodeName) {
         case 'UL':
-          el.prepend('* ')
+          bullet = '* '
           break
         case 'OL':
           if (listIndexOffset > 0 && !list.previousSibling) {
             const num = indexInList(el) + listIndexOffset + 1
-            el.prepend(`${num}\\. `)
+            bullet = `${num}\\. `
           } else {
-            el.prepend(`${indexInList(el) + 1}. `)
+            bullet = `${indexInList(el) + 1}. `
           }
       }
     }
-    return el
+
+    const indent = bullet.replace(/\S/g, ' ')
+    const text = el.textContent.trim().replace(/^/gm, indent)
+    const pre = document.createElement('pre')
+    pre.textContent = text.replace(indent, bullet)
+    return pre
   },
   OL(el) {
     const li = document.createElement('li')

--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -16,6 +16,16 @@ function indexInList(li: Element): number {
   return 0
 }
 
+function skipNode(node: Node): boolean {
+  // skip processing links that only link to the src of image within
+  return (
+    node instanceof HTMLAnchorElement &&
+    node.childNodes.length === 1 &&
+    node.childNodes[0] instanceof HTMLImageElement &&
+    node.childNodes[0].src === node.href
+  )
+}
+
 function hasContent(node: Node): boolean {
   return node.nodeName === 'IMG' || node.firstChild != null
 }
@@ -165,7 +175,7 @@ function fragmentToMarkdown(
   fn: (node: HTMLElement, content: string | HTMLElement) => void
 ): void {
   const nodeIterator = document.createNodeIterator(root, NodeFilter.SHOW_ELEMENT, function(node) {
-    if (node.nodeName in filters && (hasContent(node) || isCheckbox(node))) {
+    if (node.nodeName in filters && !skipNode(node) && (hasContent(node) || isCheckbox(node))) {
       return NodeFilter.FILTER_ACCEPT
     }
 

--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -49,6 +49,15 @@ function nestedListExclusive(li: Element): boolean {
   return false
 }
 
+function escapeAttribute(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/'/g, '&apos;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+}
+
 const filters: {[key: string]: (HTMLElement) => string | HTMLElement} = {
   INPUT(el) {
     if (el instanceof HTMLInputElement && el.checked) {
@@ -115,10 +124,18 @@ const filters: {[key: string]: (HTMLElement) => string | HTMLElement} = {
       return alt
     } else {
       const src = el.getAttribute('src')
-
       if (!src) throw new Error()
 
-      return `![${alt}](${src})`
+      const widthAttr = el.hasAttribute('width') ? ` width="${escapeAttribute(el.getAttribute('width') || '')}"` : ''
+      const heightAttr = el.hasAttribute('height')
+        ? ` height="${escapeAttribute(el.getAttribute('height') || '')}"`
+        : ''
+
+      if (widthAttr || heightAttr) {
+        return `<img alt="${escapeAttribute(alt)}"${widthAttr}${heightAttr} src="${escapeAttribute(src)}">`
+      } else {
+        return `![${alt}](${src})`
+      }
     }
   },
   LI(el) {

--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -49,11 +49,9 @@ const filters: {[key: string]: (HTMLElement) => string | HTMLElement} = {
   CODE(el) {
     const text = el.textContent
 
-    if (!el.parentNode) throw new Error()
-
-    if (el.parentNode.nodeName === 'PRE') {
-      el.textContent = text.replace(/^/gm, '    ')
-      return el.textContent
+    if (el.parentNode && el.parentNode.nodeName === 'PRE') {
+      el.textContent = `\`\`\`\n${text.replace(/\n+$/, '')}\n\`\`\``
+      return el
     }
     if (text.indexOf('`') >= 0) {
       return `\`\` ${text} \`\``
@@ -61,11 +59,12 @@ const filters: {[key: string]: (HTMLElement) => string | HTMLElement} = {
     return `\`${text}\``
   },
   PRE(el) {
-    if (!el.parentNode || !(el.parentNode instanceof HTMLElement)) throw new Error()
-
     const parent = el.parentNode
-    if (parent.nodeName === 'DIV' && parent.classList.contains('highlight')) {
-      el.textContent = el.textContent.replace(/^/gm, '    ')
+    if (parent instanceof HTMLElement && parent.nodeName === 'DIV' && parent.classList.contains('highlight')) {
+      const match = parent.className.match(/highlight-source-(\S+)/)
+      const flavor = match ? match[1] : ''
+      const text = el.textContent.replace(/\n+$/, '')
+      el.textContent = `\`\`\`${flavor}\n${text}\n\`\`\``
       el.append('\n\n')
     }
     return el

--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -97,11 +97,9 @@ const filters: {[key: string]: (HTMLElement) => string | HTMLElement} = {
     }
   },
   IMG(el) {
-    const alt = el.getAttribute('alt')
+    const alt = el.getAttribute('alt') || ''
 
-    if (!alt) throw new Error()
-
-    if (matches(el, 'emoji')) {
+    if (alt && matches(el, 'emoji')) {
       return alt
     } else {
       const src = el.getAttribute('src')

--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -91,10 +91,11 @@ const filters: {[key: string]: (HTMLElement) => string | HTMLElement} = {
       return text
     } else {
       const href = el.getAttribute('href')
-
-      if (!href) throw new Error()
-
-      return `[${text}](${href})`
+      if (href) {
+        return `[${text}](${href})`
+      } else {
+        return text
+      }
     }
   },
   IMG(el) {

--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -181,22 +181,18 @@ function fragmentToMarkdown(
   }
 }
 
-export default function selectionToMarkdown(selection: Selection): DocumentFragment {
-  let fragment = selection.getRangeAt(0).cloneContents()
+export default function selectionToMarkdown(range: Range): DocumentFragment {
+  const startNode = range.startContainer
+  if (!startNode || !startNode.parentNode || !(startNode.parentNode instanceof HTMLElement)) {
+    throw new Error('the range must start within an HTMLElement')
+  }
+  const parent = startNode.parentNode
+
+  let fragment = range.cloneContents()
   listIndexOffset = 0
 
-  if (
-    !selection.anchorNode ||
-    !selection.anchorNode.parentNode ||
-    !(selection.anchorNode.parentNode instanceof HTMLElement)
-  ) {
-    throw new Error("selection's anchorNode and parentNode must not be null")
-  }
-
-  const li = selection.anchorNode.parentNode.closest('li')
-  if (li) {
-    if (!li.parentNode) throw new Error()
-
+  const li = parent.closest('li')
+  if (li && li.parentNode) {
     if (li.parentNode.nodeName === 'OL') {
       listIndexOffset = indexInList(li)
     }

--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -102,14 +102,15 @@ const filters: {[key: string]: (HTMLElement) => string | HTMLElement} = {
   },
   A(el) {
     const text = el.textContent
+    const href = el.getAttribute('href')
+
     if (matches(el, 'user-mention', 'team-mention')) {
       return text
     } else if (matches(el, 'issue-link') && /^#\d+$/.test(text)) {
       return text
-    } else if (/^https?:/.test(text) && text === el.getAttribute('href')) {
+    } else if (/^https?:/.test(text) && text === href) {
       return text
     } else {
-      const href = el.getAttribute('href')
       if (href) {
         return `[${text}](${href})`
       } else {

--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -141,22 +141,19 @@ const filters: {[key: string]: (HTMLElement) => string | HTMLElement} = {
   },
   LI(el) {
     const list = el.parentNode
-
     if (!list) throw new Error()
 
     let bullet = ''
     if (!nestedListExclusive(el)) {
-      switch (list.nodeName) {
-        case 'UL':
-          bullet = '* '
-          break
-        case 'OL':
-          if (listIndexOffset > 0 && !list.previousSibling) {
-            const num = indexInList(el) + listIndexOffset + 1
-            bullet = `${num}\\. `
-          } else {
-            bullet = `${indexInList(el) + 1}. `
-          }
+      if (list.nodeName === 'OL') {
+        if (listIndexOffset > 0 && !list.previousSibling) {
+          const num = indexInList(el) + listIndexOffset + 1
+          bullet = `${num}\\. `
+        } else {
+          bullet = `${indexInList(el) + 1}. `
+        }
+      } else {
+        bullet = '* '
       }
     }
 

--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -83,7 +83,9 @@ const filters: {[key: string]: (HTMLElement) => string | HTMLElement} = {
   },
   A(el) {
     const text = el.textContent
-    if (matches(el, 'issue-link', 'user-mention', 'team-mention')) {
+    if (matches(el, 'user-mention', 'team-mention')) {
+      return text
+    } else if (matches(el, 'issue-link') && /^#\d+$/.test(text)) {
       return text
     } else if (/^https?:/.test(text) && text === el.getAttribute('href')) {
       return text

--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -179,7 +179,7 @@ function fragmentToMarkdown(
   }
 }
 
-export default function selectionToMarkdown(range: Range): DocumentFragment {
+export default function rangeToMarkdown(range: Range, selector?: string): DocumentFragment {
   const startNode = range.startContainer
   if (!startNode || !startNode.parentNode || !(startNode.parentNode instanceof HTMLElement)) {
     throw new Error('the range must start within an HTMLElement')
@@ -187,8 +187,15 @@ export default function selectionToMarkdown(range: Range): DocumentFragment {
   const parent = startNode.parentNode
 
   let fragment = range.cloneContents()
-  listIndexOffset = 0
+  if (selector) {
+    const contentElement = fragment.querySelector(selector)
+    if (contentElement) {
+      fragment = document.createDocumentFragment()
+      fragment.appendChild(contentElement)
+    }
+  }
 
+  listIndexOffset = 0
   const li = parent.closest('li')
   if (li && li.parentNode) {
     if (li.parentNode.nodeName === 'OL') {

--- a/quote-selection.js
+++ b/quote-selection.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import selectionToMarkdown from './markdown-parsing'
+import rangeToMarkdown from './markdown-parsing'
 
 const containers = new WeakMap()
 let installed = 0
@@ -78,9 +78,10 @@ export function quote(text: string, range: Range): boolean {
   const container = findContainer(focusNode)
   if (!container) return false
 
-  if (container.hasAttribute('data-quote-markdown')) {
+  const markdownSelector = container.getAttribute('data-quote-markdown')
+  if (markdownSelector != null) {
     try {
-      selectionText = selectFragment(selectionToMarkdown(range))
+      selectionText = selectFragment(rangeToMarkdown(range, markdownSelector))
         .replace(/^\n+/, '')
         .replace(/\s+$/, '')
     } catch (error) {

--- a/quote-selection.js.flow
+++ b/quote-selection.js.flow
@@ -10,5 +10,5 @@ declare module.exports: {
   subscribe(container: Element): Subscription;
   findContainer(el: Element): ?Element;
   findTextarea(container: Element): ?HTMLTextAreaElement;
-  quote(): boolean;
+  quote(text: string, range: Range): boolean;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -94,4 +94,52 @@ describe('quote-selection', function() {
       assert.equal(textarea.value, 'Has text')
     })
   })
+
+  describe('with markdown enabled', function() {
+    let subscription
+    beforeEach(function() {
+      document.body.innerHTML = `
+        <div data-quote data-quote-markdown=".comment-body">
+          <div>
+            <p>This should not appear as part of the quote.</p>
+            <div class="comment-body">
+              <p>This is <strong>beautifully</strong> formatted <em>text</em> that even has some <code>inline code</code>.</p>
+              <div class="highlight highlight-source-js"><pre><span class="pl-en">foo</span>(<span class="pl-c1">true</span>)</pre></div>
+              <p><a class="user-mention">@mentions</a> and <img alt=":emoji:" class="emoji" src="image.png"> are preserved.</p>
+              <blockquote><p>Music changes, and I'm gonna change right along with it.<br>--Aretha Franklin</p></blockquote>
+            </div>
+          </div>
+          <textarea></textarea>
+        </div>
+      `
+      subscription = quoteSelection.subscribe(document.querySelector('[data-quote]'))
+    })
+
+    afterEach(function() {
+      subscription.unsubscribe()
+      document.body.innerHTML = ''
+    })
+
+    it('preserves formatting', function() {
+      const range = document.createRange()
+      range.selectNodeContents(document.querySelector('.comment-body').parentNode)
+      assert.ok(quoteSelection.quote('whatever', range))
+
+      const textarea = document.querySelector('textarea')
+      assert.equal(
+        textarea.value,
+        `> This is **beautifully** formatted _text_ that even has some \`inline code\`.
+> 
+> \`\`\`js
+> foo(true)
+> \`\`\`
+> 
+> @mentions and :emoji: are preserved.
+> 
+> > Music changes, and I'm gonna change right along with it.--Aretha Franklin
+
+`
+      )
+    })
+  })
 })


### PR DESCRIPTION
* Tweak public `quote()` API for greater flexibility: now accepts a string to quote and a Range object.
* The `data-quote-markdown` attribute can now specify a content selector to scope to, eliminating all extra nodes outside of it (typically around the edges of a user selection).
* Don't halt processing on images with a blank `alt` attribute.
* Use fenced code block syntax.

/cc @github/papercuts