### PR TITLE
Quote Markdown text on clipboard copy

### DIFF
--- a/quote-selection.js
+++ b/quote-selection.js
@@ -92,15 +92,7 @@ export function quote(text: string, range: Range): boolean {
   const field = findTextarea(container)
   if (!field) return false
 
-  let quotedText = `> ${selectionText.replace(/\n/g, '\n> ')}\n\n`
-  if (field.value) {
-    quotedText = `${field.value}\n\n${quotedText}`
-  }
-  field.value = quotedText
-  field.focus()
-  field.selectionStart = field.value.length
-  field.scrollTop = field.scrollHeight
-
+  insertQuote(selectionText, field)
   return true
 }
 
@@ -136,6 +128,17 @@ function extractQuote(text: string, range: Range): ?Quote {
   }
 
   return {selectionText, container}
+}
+
+function insertQuote(selectionText: string, field: HTMLTextAreaElement) {
+  let quotedText = `> ${selectionText.replace(/\n/g, '\n> ')}\n\n`
+  if (field.value) {
+    quotedText = `${field.value}\n\n${quotedText}`
+  }
+  field.value = quotedText
+  field.focus()
+  field.selectionStart = field.value.length
+  field.scrollTop = field.scrollHeight
 }
 
 function visible(el: HTMLElement): boolean {

--- a/quote-selection.js
+++ b/quote-selection.js
@@ -22,6 +22,7 @@ export function install(container: Element) {
   installed += containers.has(container) ? 0 : 1
   containers.set(container, 1)
   document.addEventListener('keydown', quoteSelection)
+  container.addEventListener('copy', onCopy)
 }
 
 export function uninstall(container: Element) {
@@ -30,6 +31,29 @@ export function uninstall(container: Element) {
   if (!installed) {
     document.removeEventListener('keydown', quoteSelection)
   }
+  container.removeEventListener('copy', onCopy)
+}
+
+function onCopy(event: ClipboardEvent) {
+  const target = event.target
+  if (!(target instanceof HTMLElement)) return
+  if (isFormField(target)) return
+
+  const transfer = event.clipboardData
+  if (!transfer) return
+
+  const selection = window.getSelection()
+  let range
+  try {
+    range = selection.getRangeAt(0)
+  } catch (err) {
+    return
+  }
+  const quoted = extractQuote(selection.toString(), range)
+  if (!quoted) return
+
+  transfer.setData('text/plain', quoted.selectionText)
+  event.preventDefault()
 }
 
 function eventIsNotRelevant(event: KeyboardEvent): boolean {


### PR DESCRIPTION
Expands the existing <kbd>r</kbd> keyboard shortcut to include system clipboard copy events from <kbd>Command-C</kbd> and the `Copy` menu item.

If no Markdown text is available, fall back to copying the plain text as usual.