### PR TITLE
Fixes for copying and quoting Markdown

### DIFF
--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -230,7 +230,12 @@ export default function rangeToMarkdown(range: Range, selector?: string): Docume
 
   listIndexOffset = 0
   const li = parent.closest('li')
-  if (li && li.parentNode) {
+  if (parent.nodeName === 'PRE') {
+    const pre = document.createElement('pre')
+    pre.appendChild(fragment)
+    fragment = document.createDocumentFragment()
+    fragment.appendChild(pre)
+  } else if (li && li.parentNode) {
     if (li.parentNode.nodeName === 'OL') {
       listIndexOffset = indexInList(li)
     }

--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -234,12 +234,13 @@ export default function rangeToMarkdown(range: Range, selector: string, unwrap: 
 
   listIndexOffset = 0
   const li = parent.closest('li')
-  if (parent.nodeName === 'PRE') {
+  const codeBlock = parent.closest('pre')
+  if (codeBlock) {
     const pre = document.createElement('pre')
     pre.appendChild(fragment)
     let item = pre
     if (!unwrap) {
-      const pp = parent.parentNode
+      const pp = codeBlock.parentNode
       if (pp instanceof HTMLElement && isHighlightContainer(pp)) {
         const div = document.createElement('div')
         div.className = pp.className

--- a/quote-selection.js
+++ b/quote-selection.js
@@ -54,6 +54,9 @@ function onCopy(event: ClipboardEvent) {
 
   transfer.setData('text/plain', quoted.selectionText)
   event.preventDefault()
+
+  selection.removeAllRanges()
+  selection.addRange(range)
 }
 
 function eventIsNotRelevant(event: KeyboardEvent): boolean {

--- a/quote-selection.js
+++ b/quote-selection.js
@@ -49,7 +49,7 @@ function onCopy(event: ClipboardEvent) {
   } catch (err) {
     return
   }
-  const quoted = extractQuote(selection.toString(), range)
+  const quoted = extractQuote(selection.toString(), range, true)
   if (!quoted) return
 
   transfer.setData('text/plain', quoted.selectionText)
@@ -96,7 +96,7 @@ function quoteSelection(event: KeyboardEvent): void {
 }
 
 export function quote(text: string, range: Range): boolean {
-  const quoted = extractQuote(text, range)
+  const quoted = extractQuote(text, range, false)
   if (!quoted) return false
 
   const {container, selectionText} = quoted
@@ -125,7 +125,7 @@ type Quote = {
   selectionText: string
 }
 
-function extractQuote(text: string, range: Range): ?Quote {
+function extractQuote(text: string, range: Range, unwrap: boolean): ?Quote {
   let selectionText = text.trim()
   if (!selectionText) return
 
@@ -141,7 +141,7 @@ function extractQuote(text: string, range: Range): ?Quote {
   const markdownSelector = container.getAttribute('data-quote-markdown')
   if (markdownSelector != null) {
     try {
-      selectionText = selectFragment(rangeToMarkdown(range, markdownSelector))
+      selectionText = selectFragment(rangeToMarkdown(range, markdownSelector, unwrap))
         .replace(/^\n+/, '')
         .replace(/\s+$/, '')
     } catch (error) {


### PR DESCRIPTION
- When selecting partially within a `<pre>` element:
  - copying to clipboard now preserves whitespace;
  - quoting wraps the partial text in fenced code blocks.

- Restore original selection after copy to clipboard.