### PR TITLE
Disable Markdown quoting/copying for Microsoft Edge

### DIFF
--- a/quote-selection.js
+++ b/quote-selection.js
@@ -5,6 +5,8 @@ import rangeToMarkdown from './markdown-parsing'
 const containers = new WeakMap()
 let installed = 0
 
+const edgeBrowser = /\bEdge\//.test(navigator.userAgent)
+
 type Subscription = {|
   unsubscribe: () => void
 |}
@@ -22,7 +24,9 @@ export function install(container: Element) {
   installed += containers.has(container) ? 0 : 1
   containers.set(container, 1)
   document.addEventListener('keydown', quoteSelection)
-  container.addEventListener('copy', onCopy)
+  if (!edgeBrowser) {
+    container.addEventListener('copy', onCopy)
+  }
 }
 
 export function uninstall(container: Element) {
@@ -31,7 +35,9 @@ export function uninstall(container: Element) {
   if (!installed) {
     document.removeEventListener('keydown', quoteSelection)
   }
-  container.removeEventListener('copy', onCopy)
+  if (!edgeBrowser) {
+    container.removeEventListener('copy', onCopy)
+  }
 }
 
 function onCopy(event: ClipboardEvent) {
@@ -142,7 +148,7 @@ function extractQuote(text: string, range: Range, unwrap: boolean): ?Quote {
   if (!container) return
 
   const markdownSelector = container.getAttribute('data-quote-markdown')
-  if (markdownSelector != null) {
+  if (markdownSelector != null && !edgeBrowser) {
     try {
       selectionText = selectFragment(rangeToMarkdown(range, markdownSelector, unwrap))
         .replace(/^\n+/, '')

--- a/quote-selection.js
+++ b/quote-selection.js
@@ -21,9 +21,12 @@ export function subscribe(container: Element): Subscription {
 }
 
 export function install(container: Element) {
+  const firstInstall = installed === 0
   installed += containers.has(container) ? 0 : 1
   containers.set(container, 1)
-  document.addEventListener('keydown', quoteSelection)
+  if (firstInstall) {
+    document.addEventListener('keydown', quoteSelection)
+  }
   if (!edgeBrowser) {
     container.addEventListener('copy', onCopy)
   }


### PR DESCRIPTION
Edge crashes around the time the document fragment prepared for Markdown syntax is inserted into the DOM to get its string representation.

Until we figure out what exactly crashes Edge, this disables Markdown quoting and copying for that browser.