### PR TITLE
Copy markdown to clipboard with custom mime type

### DIFF
--- a/quote-selection.js
+++ b/quote-selection.js
@@ -58,10 +58,13 @@ function onCopy(event: ClipboardEvent) {
   } catch (err) {
     return
   }
-  const quoted = extractQuote(selection.toString(), range, true)
+
+  const text = selection.toString()
+  const quoted = extractQuote(text, range, true)
   if (!quoted) return
 
-  transfer.setData('text/plain', quoted.selectionText)
+  transfer.setData('text/plain', text)
+  transfer.setData('text/x-gfm', quoted.selectionText)
   event.preventDefault()
 
   selection.removeAllRanges()


### PR DESCRIPTION
Plain text is also copied to the clipboard for pasting into external apps, like a terminal or code editor. Paste listeners within the site can detect the text/x-gfm mime type and choose to paste the markdown
formatted selection instead.