### PR TITLE
Quote markdown tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ The optional `scopeSelector` parameter ensures that even if the user selection b
 
 ## Events
 
-A `quote-selection` event is fired on the quote region before text is appended to a textarea. Listen to the event to prepare the textarea or manipulate the selection text.
+* `quote-selection-markdown` (bubbles: true, cancelable: false) - fired on the quote region to optionally inject custom syntax into the `fragment` element in `quoteMarkdown: true` mode
+* `quote-selection` (bubbles: true, cancelable: true) - fired on the quote region before text is appended to a textarea
 
 For example, reveal a textarea so it can be found:
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Quote Markdown selection
+# Quote selection
 
-Install a shortcut `r` to append selected text to a `<textarea>` as a Markdown quote.
+Install a keyboard shortcut <kbd>r</kbd> to append selected text to a `<textarea>` as a Markdown quote.
 
 ## Installation
 
@@ -10,49 +10,31 @@ $ npm install @github/quote-selection
 
 ## Usage
 
-### HTML
-
 ```html
-<div data-quote-region>
+<div class="my-quote-region">
   <p>Text to quote</p>
   <textarea></textarea>
 </div>
 ```
 
-#### Quote as Markdown
-
-An optional feature to translate quoted content into Markdown format is available via the `data-quote-markdown` attribute:
-
-```html
-<div data-quote-region data-quote-markdown=".comment-body">
-  <div class="comment-body">
-    <h2><strong>Formatted</strong> text <em>to quote</em></h2>
-    <p>
-      Preserves <code>inline code</code> and
-      <a href="https://guides.github.com/features/mastering-markdown/">other features</a>.
-    </p>
-  </div>
-  <div class="comment-body">
-    <p>Some other text</p>
-  </div>
-  <textarea></textarea>
-</div>
-```
-
-When selected, the text within the first `.comment-body` element will get quoted as:
-
-```
-> ## **Formatted** text _to quote_
->
-> Preserves `inline code` and [other features](https://guides.github.com/features/mastering-markdown/).
-```
-
-### JS
-
 ```js
 import {install} from '@github/quote-selection'
-install(document.querySelector('[data-quote-region]'))
+
+install(document.querySelector('.my-quote-region'))
 ```
+
+This sets up a keyboard event handler so that selecting any text within `.my-quote-region` and pressing <kbd>r</kbd> appends the quoted representation of the selected text into the first applicable `<textarea>` element.
+
+### Preserving Markdown syntax
+
+```js
+install(element, {
+  quoteMarkdown: true,
+  scopeSelector: '.comment-body'
+})
+```
+
+The optional `scopeSelector` parameter ensures that even if the user selection bleeds outside of the scoped element, the quoted portion will always be contained inside the scope. This is useful to avoid accidentally quoting parts of the UI that might be interspersed between quotable content.
 
 ## Events
 

--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -98,6 +98,9 @@ const filters: {[key: string]: (HTMLElement) => string | HTMLElement} = {
   EM(el) {
     return `_${el.textContent}_`
   },
+  DEL(el) {
+    return `~${el.textContent}~`
+  },
   BLOCKQUOTE(el) {
     const text = el.textContent.trim().replace(/^/gm, '> ')
     const pre = document.createElement('pre')

--- a/markdown-parsing.js
+++ b/markdown-parsing.js
@@ -183,6 +183,22 @@ const filters: {[key: string]: (HTMLElement) => string | HTMLElement} = {
   },
   UL(el) {
     return el
+  },
+  DIV(el) {
+    if (el.classList.contains('js-suggested-changes-blob')) {
+      // skip quoting suggested changes widget
+      el.remove()
+    } else if (el.classList.contains('blob-wrapper-embedded')) {
+      // handle embedded blob snippets
+      const container = el.parentNode
+      if (!(container instanceof HTMLElement)) throw new Error()
+      const link = container.querySelector('a[href]')
+      if (!(link instanceof HTMLAnchorElement)) throw new Error()
+      const p = document.createElement('p')
+      p.textContent = link.href
+      container.replaceWith(p)
+    }
+    return el
   }
 }
 filters.UL = filters.OL

--- a/quote-selection.js
+++ b/quote-selection.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import rangeToMarkdown from './markdown-parsing'
+import {extractFragment, insertMarkdownSyntax} from './markdown-parsing'
 
 const containers = new WeakMap()
 let installed = 0
@@ -122,7 +122,16 @@ function extractQuote(text: string, range: Range, unwrap: boolean): ?Quote {
   const markdownSelector = container.getAttribute('data-quote-markdown')
   if (markdownSelector != null && !edgeBrowser) {
     try {
-      selectionText = selectFragment(rangeToMarkdown(range, markdownSelector, unwrap))
+      const fragment = extractFragment(range, markdownSelector)
+      container.dispatchEvent(
+        new CustomEvent('quote-selection-markdown', {
+          bubbles: true,
+          cancelable: false,
+          detail: {fragment, range, unwrap}
+        })
+      )
+      insertMarkdownSyntax(fragment)
+      selectionText = selectFragment(fragment)
         .replace(/^\n+/, '')
         .replace(/\s+$/, '')
     } catch (error) {

--- a/quote-selection.js
+++ b/quote-selection.js
@@ -2,17 +2,27 @@
 
 import {extractFragment, insertMarkdownSyntax} from './markdown-parsing'
 
-const containers = new WeakMap()
+const containers: WeakMap<Element, ContainerConfig> = new WeakMap()
 let installed = 0
 
 const edgeBrowser = /\bEdge\//.test(navigator.userAgent)
+
+type ConfigOptions = {|
+  quoteMarkdown?: boolean,
+  scopeSelector?: string
+|}
+
+type ContainerConfig = {|
+  quoteMarkdown: boolean,
+  scopeSelector: string
+|}
 
 type Subscription = {|
   unsubscribe: () => void
 |}
 
-export function subscribe(container: Element): Subscription {
-  install(container)
+export function subscribe(container: Element, options?: ConfigOptions): Subscription {
+  install(container, options)
   return {
     unsubscribe: () => {
       uninstall(container)
@@ -20,10 +30,11 @@ export function subscribe(container: Element): Subscription {
   }
 }
 
-export function install(container: Element) {
+export function install(container: Element, options?: ConfigOptions) {
   const firstInstall = installed === 0
   installed += containers.has(container) ? 0 : 1
-  containers.set(container, 1)
+  const config: ContainerConfig = Object.assign({quoteMarkdown: false, scopeSelector: ''}, options)
+  containers.set(container, config)
   if (firstInstall) {
     document.addEventListener('keydown', quoteSelection)
   }
@@ -118,11 +129,12 @@ function extractQuote(text: string, range: Range, unwrap: boolean): ?Quote {
 
   const container = findContainer(focusNode)
   if (!container) return
+  const options = containers.get(container)
+  if (!options) return
 
-  const markdownSelector = container.getAttribute('data-quote-markdown')
-  if (markdownSelector != null && !edgeBrowser) {
+  if (options.quoteMarkdown && !edgeBrowser) {
     try {
-      const fragment = extractFragment(range, markdownSelector)
+      const fragment = extractFragment(range, options.scopeSelector)
       container.dispatchEvent(
         new CustomEvent('quote-selection-markdown', {
           bubbles: true,

--- a/quote-selection.js.flow
+++ b/quote-selection.js.flow
@@ -1,13 +1,18 @@
 /* @flow strict */
 
+type ConfigOptions = {|
+  quoteMarkdown?: boolean,
+  scopeSelector?: string
+|}
+
 interface Subscription {
   unsubscribe: () => void
 }
 
 declare module.exports: {
-  install(container: Element): void;
+  install(container: Element, options?: ConfigOptions): void;
   uninstall(container: Element): void;
-  subscribe(container: Element): Subscription;
+  subscribe(container: Element, options?: ConfigOptions): Subscription;
   findContainer(el: Element): ?Element;
   findTextarea(container: Element): ?HTMLTextAreaElement;
   quote(text: string, range: Range): boolean;

--- a/test/test.js
+++ b/test/test.js
@@ -61,15 +61,6 @@ describe('quote-selection', function() {
       assert.equal(textarea.value, 'Has text\n\n> Test Quotable text, bold.\n\n')
       assert.equal(eventCount, 1)
       assert.equal(changeCount, 1)
-
-      container.setAttribute('data-quote-markdown', '')
-      quote()
-      assert.equal(
-        textarea.value,
-        'Has text\n\n> Test Quotable text, bold.\n\n\n\n> Test [Quotable](#) text, **bold**.\n\n'
-      )
-      assert.equal(eventCount, 2)
-      assert.equal(changeCount, 2)
     })
 
     it('nested textarea is updated when event is captured', function() {
@@ -104,7 +95,7 @@ describe('quote-selection', function() {
     let subscription
     beforeEach(function() {
       document.body.innerHTML = `
-        <div data-quote data-quote-markdown=".comment-body">
+        <div data-quote>
           <div>
             <p>This should not appear as part of the quote.</p>
             <div class="comment-body">
@@ -117,7 +108,10 @@ describe('quote-selection', function() {
           <textarea></textarea>
         </div>
       `
-      subscription = quoteSelection.subscribe(document.querySelector('[data-quote]'))
+      subscription = quoteSelection.subscribe(document.querySelector('[data-quote]'), {
+        quoteMarkdown: true,
+        scopeSelector: '.comment-body'
+      })
     })
 
     afterEach(function() {

--- a/test/test.js
+++ b/test/test.js
@@ -109,8 +109,8 @@ describe('quote-selection', function() {
             <p>This should not appear as part of the quote.</p>
             <div class="comment-body">
               <p>This is <strong>beautifully</strong> formatted <em>text</em> that even has some <code>inline code</code>.</p>
-              <div class="highlight highlight-source-js"><pre><span class="pl-en">foo</span>(<span class="pl-c1">true</span>)</pre></div>
-              <p><a class="user-mention">@mentions</a> and <img alt=":emoji:" class="emoji" src="image.png"> are preserved.</p>
+              <pre><code>foo(true)</code></pre>
+              <p><a href="http://example.com">Links</a> and <img alt=":emoji:" class="emoji" src="image.png"> are preserved.</p>
               <blockquote><p>Music changes, and I'm gonna change right along with it.<br>--Aretha Franklin</p></blockquote>
             </div>
           </div>
@@ -132,19 +132,34 @@ describe('quote-selection', function() {
 
       const textarea = document.querySelector('textarea')
       assert.equal(
-        textarea.value.replace(/[ ]+\n/g, '\n'),
+        textarea.value.replace(/ +\n/g, '\n'),
         `> This is **beautifully** formatted _text_ that even has some \`inline code\`.
 >
-> \`\`\`js
+> \`\`\`
 > foo(true)
 > \`\`\`
 >
-> @mentions and :emoji: are preserved.
+> [Links](http://example.com) and ![:emoji:](image.png) are preserved.
 >
 > > Music changes, and I'm gonna change right along with it.--Aretha Franklin
 
 `
       )
+    })
+
+    it('allows quote-selection-markdown event to prepare content', function() {
+      document.querySelector('[data-quote]').addEventListener('quote-selection-markdown', function(event) {
+        const {fragment} = event.detail
+        fragment.querySelector('a[href]').replaceWith('@links')
+        fragment.querySelector('img[alt]').replaceWith(':emoji:')
+      })
+
+      const range = document.createRange()
+      range.selectNodeContents(document.querySelector('.comment-body').parentNode)
+      assert.ok(quoteSelection.quote('whatever', range))
+
+      const textarea = document.querySelector('textarea')
+      assert.match(textarea.value, /^> @links and :emoji: are preserved\./m)
     })
   })
 })


### PR DESCRIPTION
- Preserve ~strikethrough~ when quoting markdown
- "Suggested Changes" blocks are omitted when quoting markdown
- Blob snippets are quoted simply as the original blob link that generated the snippet