### PR TITLE
Use github-lint binary as lint command

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "scripts": {
     "clean": "rm -rf dist",
-    "lint": "eslint . && flow check",
+    "lint": "github-lint",
     "prebuild": "npm run clean && npm run lint && mkdir dist",
     "build": "rollup -c && cp quote-selection.js.flow dist/quote-selection.esm.js.flow && cp quote-selection.js.flow dist/quote-selection.umd.js.flow",
     "pretest": "npm run build",


### PR DESCRIPTION
Instead of invoking `eslint` and `flow` by ourselves we can do it via `github-lint`. This will mean that any updates that we want to do to our linting setup, we can do in `eslint-plugin-github` and just update that package in this repo and gain all the benefits from those changes.