### PR TITLE
Use correct createNodeIterator api

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -165,14 +165,14 @@ for (let level = 2; level <= 6; ++level) {
 }
 
 export function insertMarkdownSyntax(root: DocumentFragment): void {
-  // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-  // @ts-ignore
-  const nodeIterator = document.createNodeIterator(root, NodeFilter.SHOW_ELEMENT, function (node: Node) {
-    if (node.nodeName in filters && !skipNode(node) && (hasContent(node) || isCheckbox(node))) {
-      return NodeFilter.FILTER_ACCEPT
-    }
+  const nodeIterator = document.createNodeIterator(root, NodeFilter.SHOW_ELEMENT, {
+    acceptNode(node: Node) {
+      if (node.nodeName in filters && !skipNode(node) && (hasContent(node) || isCheckbox(node))) {
+        return NodeFilter.FILTER_ACCEPT
+      }
 
-    return NodeFilter.FILTER_SKIP
+      return NodeFilter.FILTER_SKIP
+    }
   })
   const results: HTMLElement[] = []
   let node = nodeIterator.nextNode()


### PR DESCRIPTION
### What?

Update the `document.createNodeIterator` call to use the correct API.

### Why?

It seems that there is some backwards compatibility that allows you to pass the `acceptNode` directly as a third parameter to `createNodeIterator` as evidenced by this code working. Additionally it seems that the MDN web docs showed a example of the "old" API as well before [I changed it](https://wiki.developer.mozilla.org/en-US/docs/Web/API/Document/createNodeIterator$compare?locale=en-US&to=1616726&from=1613730).

This change means we are using the function as how it is described in the spec as well as allowing us to remove a `@ts-ignore` comment.

### References

- https://dom.spec.whatwg.org/#concept-traversal-filter
- https://wiki.developer.mozilla.org/en-US/docs/Web/API/Document/createNodeIterator
- https://github.com/github/github/pull/140272#issuecomment-612969112