### PR TITLE
Minor: Pass container target with quote-selection event

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,10 +48,10 @@ For example, reveal a textarea so it can be found:
 
 ```js
 region.addEventListener('quote-selection', function(event) {
-  const {selection, selectionText} = event.detail
-  console.log('Quoted text', selection, selectionText)
+  const {selectionText, container} = event.detail
+  console.log('Quoted text', selectionText)
 
-  const textarea = event.target.querySelector('textarea')
+  const textarea = container.querySelector('textarea')
   textarea.hidden = false
 
   // Cancel the quote behavior.

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,7 @@ export function quote(text: string, range: Range): boolean {
     new CustomEvent('quote-selection', {
       bubbles: true,
       cancelable: true,
-      detail: {range, selectionText}
+      detail: {range, selectionText, container}
     })
   )
 


### PR DESCRIPTION
In testing https://github.com/github/github/pull/151548 I remembered that this event exists 🤦🏻‍♀️ . 

However, since this event is fired on the parent container, it'd benefit the listeners to send the target quote region as well. The quote region is found through the `scopeSelector`. Listeners shouldn't have to re-query the region and risk getting a different target than the one `quote-selection` found.

We use this container to determine which textarea the quote should go to.
