### PR TITLE
Escape specific html tags in P elements when quoting to markdown

### DIFF
--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -76,6 +76,12 @@ const filters: Filters = {
     }
     return `\`${text}\``
   },
+  P(el) {
+    const pElement = document.createElement('p')
+    const text = el.textContent || ''
+    pElement.textContent = text.replace(/<(\/?)(pre|strong|weak|em)>/g, '\\<$1$2\\>')
+    return pElement
+  },
   STRONG(el) {
     return `**${el.textContent || ''}**`
   },

--- a/test/test.js
+++ b/test/test.js
@@ -103,7 +103,7 @@ describe('quote-selection', function () {
             <div class="comment-body">
               <p>This is <strong>beautifully</strong> formatted <em>text</em> that even has some <code>inline code</code>.</p>
               <p>This is a simple p line</p>
-              <p>some escpaed html tags to ignore &lt;pre&gt; &lt;strong&gt; &lt;weak&gt; &lt;em&gt; &lt;/pre&gt; &lt;/strong&gt; &lt;/weak&gt; &lt;/em&gt;</p> 
+              <p>some escaped html tags to ignore &lt;pre&gt; &lt;strong&gt; &lt;weak&gt; &lt;em&gt; &lt;/pre&gt; &lt;/strong&gt; &lt;/weak&gt; &lt;/em&gt;</p> 
               <pre><code>foo(true)</code></pre>
               <p><a href="http://example.com">Links</a> and <img alt=":emoji:" class="emoji" src="image.png"> are preserved.</p>
               <blockquote><p>Music changes, and I'm gonna change right along with it.<br>--Aretha Franklin</p></blockquote>
@@ -135,7 +135,7 @@ describe('quote-selection', function () {
 >
 > This is a simple p line
 >
-> some escpaed html tags to ignore \\<pre\\> \\<strong\\> \\<weak\\> \\<em\\> \\</pre\\> \\</strong\\> \\</weak\\> \\</em\\>
+> some escaped html tags to ignore \\<pre\\> \\<strong\\> \\<weak\\> \\<em\\> \\</pre\\> \\</strong\\> \\</weak\\> \\</em\\>
 >
 > \`\`\`
 > foo(true)

--- a/test/test.js
+++ b/test/test.js
@@ -102,6 +102,8 @@ describe('quote-selection', function () {
             <p>This should not appear as part of the quote.</p>
             <div class="comment-body">
               <p>This is <strong>beautifully</strong> formatted <em>text</em> that even has some <code>inline code</code>.</p>
+              <p>This is a simple p line</p>
+              <p>some escpaed html tags to ignore &lt;pre&gt; &lt;strong&gt; &lt;weak&gt; &lt;em&gt; &lt;/pre&gt; &lt;/strong&gt; &lt;/weak&gt; &lt;/em&gt;</p> 
               <pre><code>foo(true)</code></pre>
               <p><a href="http://example.com">Links</a> and <img alt=":emoji:" class="emoji" src="image.png"> are preserved.</p>
               <blockquote><p>Music changes, and I'm gonna change right along with it.<br>--Aretha Franklin</p></blockquote>
@@ -130,6 +132,10 @@ describe('quote-selection', function () {
       assert.equal(
         textarea.value.replace(/ +\n/g, '\n'),
         `> This is **beautifully** formatted _text_ that even has some \`inline code\`.
+>
+> This is a simple p line
+>
+> some escpaed html tags to ignore \\<pre\\> \\<strong\\> \\<weak\\> \\<em\\> \\</pre\\> \\</strong\\> \\</weak\\> \\</em\\>
 >
 > \`\`\`
 > foo(true)


### PR DESCRIPTION
This PR adds a small fix to support escaping html tags inside a P element when converting to markdown. 
Before this change if a text contained an escaped html tag like:

\<pre> Hello \</pre> 

It would be quoted as
<pre> Hello </pre> 

See the before and after in this image, where the top comment is the one being quoted.
Notice how the middle comment (before this change) wrongfully converts `<pre> nothing </pre>` into a highlighted part with only the text `nothing` in it: 
![image](https://user-images.githubusercontent.com/11458012/128162633-20c6da88-618d-4761-b1a0-1db4980ba694.png)

I decided to match for a specific list of tags `pre|strong|weak|em` for now in order to minimize the risk of this capturing some things it shouldn't. 

* Related bug: https://github.com/github/issues/issues/1859

Please let me know if any other tags should be added here. 