### PR TITLE
Allow custom shortcut binding, outside of default `r`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ region.addEventListener('quote-selection', function(event) {
 })
 ```
 
+## Custom shortcut
+
+The default shortcut is <kbd>r</kbd>. Change this shortcut by setting `shortcut`.
+
+```js
+install(element, {
+  quoteMarkdown: true,
+  copyMarkdown: false,
+  shortcut: 'Meta+Shift+c'
+})
+```
+
 ## Development
 
 ```


### PR DESCRIPTION
The quote selection behavior is currently bound to `r`. 

This PR allows this key binding to be customized, or turned off.

 > The default shortcut is <kbd>r</kbd>. Change this shortcut by setting `shortcut`.

```js
install(element, {
  quoteMarkdown: true,
  copyMarkdown: false,
  shortcut: 'Meta+Shift+c'
})
```

See [this comment](https://github.com/github/accessibility/issues/300#issuecomment-943851400) for more context. 