### PR TITLE
Replace uninstall with abortcontroller

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ $ npm install @github/quote-selection
 ```js
 import {install} from '@github/quote-selection'
 
-install(document.querySelector('.my-quote-region'))
+const controller = new AbortController()
+
+install(document.querySelector('.my-quote-region'), { signal: controller.signal })
+
+// For when you want to uninstall later:
+const uninstall = () => controller.abort()
 ```
 
 This sets up a keyboard event handler so that selecting any text within `.my-quote-region` and pressing <kbd>r</kbd> appends the quoted representation of the selected text into the first applicable `<textarea>` element.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,6 @@ import {extractFragment, insertMarkdownSyntax} from './markdown'
 const containers: WeakMap<Element, Options> = new WeakMap()
 let installed = 0
 
-const edgeBrowser = /\bEdge\//.test(navigator.userAgent)
-
 type Options = {
   quoteMarkdown: boolean
   copyMarkdown: boolean
@@ -175,7 +173,7 @@ function extractQuote(text: string, range: Range, unwrap: boolean): Quote | unde
   const options = containers.get(container)
   if (!options) return
 
-  if (options.quoteMarkdown && !edgeBrowser) {
+  if (options.quoteMarkdown) {
     try {
       const fragment = extractFragment(range, options.scopeSelector)
       container.dispatchEvent(

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,19 +9,6 @@ type Options = {
   scopeSelector: string
 }
 
-type Subscription = {
-  unsubscribe: () => void
-}
-
-export function subscribe(container: Element, options?: Partial<Options>): Subscription {
-  install(container, options)
-  return {
-    unsubscribe: () => {
-      uninstall(container)
-    }
-  }
-}
-
 export function install(container: Element, options?: Partial<Options>) {
   const firstInstall = installed === 0
   installed += containers.has(container) ? 0 : 1

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,9 @@
 import {extractFragment, insertMarkdownSyntax} from './markdown'
 
 const containers: WeakMap<Element, Options> = new WeakMap()
-let installed = 0
+const controllers: WeakMap<Element, AbortController> = new WeakMap()
+
+let firstInstall = true
 
 type Options = {
   quoteMarkdown: boolean
@@ -10,8 +12,6 @@ type Options = {
 }
 
 export function install(container: Element, options?: Partial<Options>) {
-  const firstInstall = installed === 0
-  installed += containers.has(container) ? 0 : 1
   const config: Options = Object.assign(
     {
       quoteMarkdown: false,
@@ -21,11 +21,19 @@ export function install(container: Element, options?: Partial<Options>) {
     options
   )
   containers.set(container, config)
+  const controller = new AbortController()
+  controllers.set(container, controller)
   if (firstInstall) {
-    document.addEventListener('keydown', quoteSelection)
+    document.addEventListener('keydown', quoteSelection, {signal: controller.signal})
+    controller.signal.addEventListener('abort', () => {
+      firstInstall = true
+    })
+    firstInstall = false
   }
   if (config.copyMarkdown) {
-    ;(container as HTMLElement).addEventListener('copy', onCopy)
+    ;(container as HTMLElement).addEventListener('copy', onCopy, {
+      signal: controller.signal
+    })
   }
 }
 
@@ -33,13 +41,8 @@ export function uninstall(container: Element) {
   const config = containers.get(container)
   if (config == null) return
   containers.delete(container)
-  installed -= 1
-  if (installed === 0) {
-    document.removeEventListener('keydown', quoteSelection)
-  }
-  if (config.copyMarkdown) {
-    ;(container as HTMLElement).removeEventListener('copy', onCopy)
-  }
+  controllers.get(container)?.abort()
+  controllers.delete(container)
 }
 
 function onCopy(event: ClipboardEvent) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ type Options = {
   quoteMarkdown: boolean
   copyMarkdown: boolean
   scopeSelector: string
+  signal?: AbortSignal
 }
 
 export function install(container: Element, options?: Partial<Options>) {
@@ -20,9 +21,17 @@ export function install(container: Element, options?: Partial<Options>) {
     },
     options
   )
+  if (options?.signal) {
+    options.signal.addEventListener('abort', function () {
+      controller.abort()
+    })
+  }
   containers.set(container, config)
   const controller = new AbortController()
-  controllers.set(container, controller)
+  controller.signal.addEventListener('abort', function () {
+    containers.delete(container)
+    controllers.delete(container)
+  })
   if (firstInstall) {
     document.addEventListener('keydown', (e: KeyboardEvent) => quoteSelection(e, config), {signal: controller.signal})
     controller.signal.addEventListener('abort', () => {
@@ -38,11 +47,7 @@ export function install(container: Element, options?: Partial<Options>) {
 }
 
 export function uninstall(container: Element) {
-  const config = containers.get(container)
-  if (config == null) return
-  containers.delete(container)
   controllers.get(container)?.abort()
-  controllers.delete(container)
 }
 
 function onCopy(event: ClipboardEvent, options: Partial<Options>) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 import {extractFragment, insertMarkdownSyntax} from './markdown'
 
 const containers: WeakMap<Element, Options> = new WeakMap()
-const controllers: WeakMap<Element, AbortController> = new WeakMap()
 
 let firstInstall = true
 
@@ -21,33 +20,19 @@ export function install(container: Element, options?: Partial<Options>) {
     },
     options
   )
-  if (options?.signal) {
-    options.signal.addEventListener('abort', function () {
-      controller.abort()
-    })
-  }
   containers.set(container, config)
-  const controller = new AbortController()
-  controller.signal.addEventListener('abort', function () {
-    containers.delete(container)
-    controllers.delete(container)
-  })
   if (firstInstall) {
-    document.addEventListener('keydown', (e: KeyboardEvent) => quoteSelection(e, config), {signal: controller.signal})
-    controller.signal.addEventListener('abort', () => {
+    document.addEventListener('keydown', (e: KeyboardEvent) => quoteSelection(e, config), {signal: options?.signal})
+    options?.signal?.addEventListener('abort', () => {
       firstInstall = true
     })
     firstInstall = false
   }
   if (config.copyMarkdown) {
     ;(container as HTMLElement).addEventListener('copy', (e: ClipboardEvent) => onCopy(e, config), {
-      signal: controller.signal
+      signal: options?.signal
     })
   }
-}
-
-export function uninstall(container: Element) {
-  controllers.get(container)?.abort()
 }
 
 function onCopy(event: ClipboardEvent, options: Partial<Options>) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import {install, subscribe, quote, uninstall} from '../dist/index.js'
+import {install, quote, uninstall} from '../dist/index.js'
 
 function createSelection(selection, el) {
   const range = document.createRange()
@@ -18,7 +18,6 @@ function quoteShortcut() {
 
 describe('quote-selection', function () {
   describe('with quotable selection', function () {
-    let subscription
     beforeEach(function () {
       document.body.innerHTML = `
         <p id="not-quotable">Not quotable text</p>
@@ -32,12 +31,12 @@ describe('quote-selection', function () {
         </div>
       `
       install(document.querySelector('[data-quote]'))
-      subscription = subscribe(document.querySelector('[data-nested-quote]'))
+      install(document.querySelector('[data-nested-quote]'))
     })
 
     afterEach(function () {
       uninstall(document.querySelector('[data-quote]'))
-      subscription.unsubscribe()
+      uninstall(document.querySelector('[data-nested-quote]'))
       document.body.innerHTML = ''
     })
 
@@ -94,7 +93,6 @@ describe('quote-selection', function () {
   })
 
   describe('with markdown enabled', function () {
-    let subscription
     beforeEach(function () {
       document.body.innerHTML = `
         <div data-quote>
@@ -112,14 +110,14 @@ describe('quote-selection', function () {
           <textarea></textarea>
         </div>
       `
-      subscription = subscribe(document.querySelector('[data-quote]'), {
+      install(document.querySelector('[data-quote]'), {
         quoteMarkdown: true,
         scopeSelector: '.comment-body'
       })
     })
 
     afterEach(function () {
-      subscription.unsubscribe()
+      uninstall(document.querySelector('[data-quote]'))
       document.body.innerHTML = ''
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -124,7 +124,12 @@ describe('quote-selection', function () {
     it('preserves formatting', function () {
       const range = document.createRange()
       range.selectNodeContents(document.querySelector('.comment-body').parentNode)
-      assert.ok(quote('whatever', range))
+      assert.ok(
+        quote('whatever', range, {
+          quoteMarkdown: true,
+          scopeSelector: '.comment-body'
+        })
+      )
 
       const textarea = document.querySelector('textarea')
       assert.equal(
@@ -156,7 +161,12 @@ describe('quote-selection', function () {
 
       const range = document.createRange()
       range.selectNodeContents(document.querySelector('.comment-body').parentNode)
-      assert.ok(quote('whatever', range))
+      assert.ok(
+        quote('whatever', range, {
+          quoteMarkdown: true,
+          scopeSelector: '.comment-body'
+        })
+      )
 
       const textarea = document.querySelector('textarea')
       assert.match(textarea.value, /^> @links and :emoji: are preserved\./m)

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import {install, quote, uninstall} from '../dist/index.js'
+import {install, quote} from '../dist/index.js'
 
 function createSelection(selection, el) {
   const range = document.createRange()
@@ -18,6 +18,8 @@ function quoteShortcut() {
 
 describe('quote-selection', function () {
   describe('with quotable selection', function () {
+    let controller
+
     beforeEach(function () {
       document.body.innerHTML = `
         <p id="not-quotable">Not quotable text</p>
@@ -30,13 +32,14 @@ describe('quote-selection', function () {
           <textarea id="not-hidden-textarea">Has text</textarea>
         </div>
       `
-      install(document.querySelector('[data-quote]'))
-      install(document.querySelector('[data-nested-quote]'))
+      controller = new AbortController()
+
+      install(document.querySelector('[data-quote]'), {signal: controller.signal})
+      install(document.querySelector('[data-nested-quote]'), {signal: controller.signal})
     })
 
     afterEach(function () {
-      uninstall(document.querySelector('[data-quote]'))
-      uninstall(document.querySelector('[data-nested-quote]'))
+      controller.abort()
       document.body.innerHTML = ''
     })
 
@@ -93,6 +96,7 @@ describe('quote-selection', function () {
   })
 
   describe('with markdown enabled', function () {
+    let controller
     beforeEach(function () {
       document.body.innerHTML = `
         <div data-quote>
@@ -110,14 +114,16 @@ describe('quote-selection', function () {
           <textarea></textarea>
         </div>
       `
+      controller = new AbortController()
       install(document.querySelector('[data-quote]'), {
         quoteMarkdown: true,
-        scopeSelector: '.comment-body'
+        scopeSelector: '.comment-body',
+        signal: controller.signal
       })
     })
 
     afterEach(function () {
-      uninstall(document.querySelector('[data-quote]'))
+      controller.abort()
       document.body.innerHTML = ''
     })
 


### PR DESCRIPTION
## What?

This PR removes `subscribe`/`unsubscribe` and also `uninstall` in favour of one single interface: `install(container, { signal })`. `signal` is an `AbortSignal` which can be triggered to invoke the same behaviour `uninstall` did.

We also drop "support" for Edge 18 in this PR.

This should be considered a breaking change. 

## Why?

I think the commits explain each decision quite nicely, but to quote:

> Subscribe is useful in a world where Observables move forward, but that looks somewhat unlikely, and it's a fairly un-idiomatic pattern outside of Observables. There are better mechanisms for this. If someone needs to wrap this library in an Observable, install/uninstall can be wrapped directly.

> [Using AbortSignal] drastically reduces the amount of complex state we need to keep track of just to unbind event listeners.

> [Allowing] users calling the `install()` method to supply their own `signal` negates the need for `uninstall()`, as aborting the given signal has the same effect.
