### PR TITLE
Remove install

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,11 @@ $ npm install @github/quote-selection
 ```
 
 ```js
-import {install, getSelectionContext, quote} from '@github/quote-selection'
-
-// Install must be called!
-install(document.querySelector('.my-quote-region'))
+import {getSelectionContext, quote} from '@github/quote-selection'
 
 document.addEventListener('keydown', event => {
   if (event.key == 'r') {
-    quote(getSelectionContext())
+    quote(getSelectionContext(), { containerSelector: '.my-quote-region' })
   }
 })
 ```
@@ -35,11 +32,10 @@ Calling `quote` with `getSelectionContext` will take the currently selected HTML
 ### Preserving Markdown syntax
 
 ```js
-install(element)
-
 quote(getSelectionContext(), {
   quoteMarkdown: true,
-  scopeSelector: '.comment-body'
+  scopeSelector: '.comment-body',
+  containerSelector: '.my-quote-region'
 })
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Quote selection
 
-Install a keyboard shortcut <kbd>r</kbd> to append selected text to a `<textarea>` as a Markdown quote.
+Helpers for quoting selected text, appending the text into a `<textarea>` as a Markdown quote.
 
 ## Installation
 
@@ -18,17 +18,19 @@ $ npm install @github/quote-selection
 ```
 
 ```js
-import {install} from '@github/quote-selection'
+import {install, getSelectionContext, quote} from '@github/quote-selection'
 
-const controller = new AbortController()
+// Install must be called!
+install(document.querySelector('.my-quote-region'))
 
-install(document.querySelector('.my-quote-region'), { signal: controller.signal })
-
-// For when you want to uninstall later:
-const uninstall = () => controller.abort()
+document.addEventListener('keydown', event => {
+  if (event.key == 'r') {
+    quote(getSelectionContext())
+  }
+})
 ```
 
-This sets up a keyboard event handler so that selecting any text within `.my-quote-region` and pressing <kbd>r</kbd> appends the quoted representation of the selected text into the first applicable `<textarea>` element.
+Calling `quote` with `getSelectionContext` will take the currently selected HTML, converts it to markdown, and appends the quoted representation of the selected text into the first applicable `<textarea>` element.
 
 ### Preserving Markdown syntax
 
@@ -36,6 +38,11 @@ This sets up a keyboard event handler so that selecting any text within `.my-quo
 install(element, {
   quoteMarkdown: true,
   copyMarkdown: false,
+  scopeSelector: '.comment-body'
+})
+
+quote(getSelectionContext(), {
+  quoteMarkdown: true,
   scopeSelector: '.comment-body'
 })
 ```
@@ -46,13 +53,13 @@ In `copyMarkdown: true` mode, the browser clipboard copy action is intercepted f
 
 ## Events
 
-* `quote-selection-markdown` (bubbles: true, cancelable: false) - fired on the quote region to optionally inject custom syntax into the `fragment` element in `quoteMarkdown: true` mode
-* `quote-selection` (bubbles: true, cancelable: true) - fired on the quote region before text is appended to a textarea
+- `quote-selection-markdown` (bubbles: true, cancelable: false) - fired on the quote region to optionally inject custom syntax into the `fragment` element in `quoteMarkdown: true` mode
+- `quote-selection` (bubbles: true, cancelable: true) - fired on the quote region before text is appended to a textarea
 
 For example, reveal a textarea so it can be found:
 
 ```js
-region.addEventListener('quote-selection', function(event) {
+region.addEventListener('quote-selection', function (event) {
   const {selection, selectionText} = event.detail
   console.log('Quoted text', selection, selectionText)
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ Calling `quote` with `getSelectionContext` will take the currently selected HTML
 ```js
 install(element, {
   quoteMarkdown: true,
-  copyMarkdown: false,
   scopeSelector: '.comment-body'
 })
 
@@ -48,8 +47,6 @@ quote(getSelectionContext(), {
 ```
 
 The optional `scopeSelector` parameter ensures that even if the user selection bleeds outside of the scoped element, the quoted portion will always be contained inside the scope. This is useful to avoid accidentally quoting parts of the UI that might be interspersed between quotable content.
-
-In `copyMarkdown: true` mode, the browser clipboard copy action is intercepted for user selections within `element` and the Markdown representation of the content is placed on clipboard under the `text/x-gfm` MIME-type.
 
 ## Events
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,7 @@ Calling `quote` with `getSelectionContext` will take the currently selected HTML
 ### Preserving Markdown syntax
 
 ```js
-install(element, {
-  quoteMarkdown: true,
-  scopeSelector: '.comment-body'
-})
+install(element)
 
 quote(getSelectionContext(), {
   quoteMarkdown: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,9 @@
 import {extractFragment, insertMarkdownSyntax} from './markdown'
 
-const containers: WeakSet<Element> = new WeakSet()
-
 type Options = {
   quoteMarkdown: boolean
   scopeSelector: string
+  containerSelector: string
 }
 
 interface SelectionContext {
@@ -19,19 +18,6 @@ export function getSelectionContext(): SelectionContext | null {
     return {text: selection.toString(), range: selection.getRangeAt(0)}
   } catch {
     return null
-  }
-}
-
-export function install(container: Element) {
-  containers.add(container)
-}
-
-export function findContainer(el: Element): Element | undefined {
-  let parent: Element | null = el
-  while ((parent = parent.parentElement)) {
-    if (containers.has(parent)) {
-      return parent
-    }
   }
 }
 
@@ -87,7 +73,9 @@ function extractQuote(
   if (focusNode.nodeType !== Node.ELEMENT_NODE) focusNode = focusNode.parentNode
   if (!(focusNode instanceof Element)) return
 
-  const container = findContainer(focusNode)
+  if (!options?.containerSelector) return
+
+  const container = focusNode.closest(options.containerSelector)
   if (!container) return
 
   if (options?.quoteMarkdown) {
@@ -157,15 +145,4 @@ function selectFragment(fragment: DocumentFragment): string {
     body.removeChild(div)
   }
   return selectionText
-}
-
-function isFormField(element: HTMLElement): boolean {
-  const name = element.nodeName.toLowerCase()
-  const type = (element.getAttribute('type') || '').toLowerCase()
-  return (
-    name === 'select' ||
-    name === 'textarea' ||
-    (name === 'input' && type !== 'submit' && type !== 'reset') ||
-    element.isContentEditable
-  )
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,6 @@ import {extractFragment, insertMarkdownSyntax} from './markdown'
 
 const containers: WeakMap<Element, Options> = new WeakMap()
 
-let firstInstall = true
-
 type Options = {
   quoteMarkdown: boolean
   copyMarkdown: boolean
@@ -36,13 +34,6 @@ export function install(container: Element, options?: Partial<Options>) {
     options
   )
   containers.set(container, config)
-  if (firstInstall) {
-    document.addEventListener('keydown', (e: KeyboardEvent) => quoteSelection(e, config), {signal: options?.signal})
-    options?.signal?.addEventListener('abort', () => {
-      firstInstall = true
-    })
-    firstInstall = false
-  }
   if (config.copyMarkdown) {
     ;(container as HTMLElement).addEventListener('copy', (e: ClipboardEvent) => onCopy(e, config), {
       signal: options?.signal
@@ -74,18 +65,6 @@ function onCopy(event: ClipboardEvent, options: Partial<Options>) {
   selection.addRange(selectionContext.range)
 }
 
-function eventIsNotRelevant(event: KeyboardEvent): boolean {
-  return (
-    event.defaultPrevented ||
-    event.key !== 'r' ||
-    event.metaKey ||
-    event.altKey ||
-    event.shiftKey ||
-    event.ctrlKey ||
-    (event.target instanceof HTMLElement && isFormField(event.target))
-  )
-}
-
 export function findContainer(el: Element): Element | undefined {
   let parent: Element | null = el
   while ((parent = parent.parentElement)) {
@@ -100,17 +79,6 @@ export function findTextarea(container: Element): HTMLTextAreaElement | undefine
     if (field instanceof HTMLTextAreaElement && visible(field)) {
       return field
     }
-  }
-}
-
-export function quoteSelection(event: KeyboardEvent, options: Partial<Options>): void {
-  if (eventIsNotRelevant(event)) return
-
-  const selection = getSelectionContext()
-  if (!selection) return
-
-  if (quote(selection, options)) {
-    event.preventDefault()
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ const containers: WeakMap<Element, Options> = new WeakMap()
 
 type Options = {
   quoteMarkdown: boolean
-  copyMarkdown: boolean
   scopeSelector: string
   signal?: AbortSignal
 }
@@ -34,35 +33,6 @@ export function install(container: Element, options?: Partial<Options>) {
     options
   )
   containers.set(container, config)
-  if (config.copyMarkdown) {
-    ;(container as HTMLElement).addEventListener('copy', (e: ClipboardEvent) => onCopy(e, config), {
-      signal: options?.signal
-    })
-  }
-}
-
-function onCopy(event: ClipboardEvent, options: Partial<Options>) {
-  const target = event.target
-  if (!(target instanceof HTMLElement)) return
-  if (isFormField(target)) return
-
-  const transfer = event.clipboardData
-  if (!transfer) return
-
-  const selectionContext = getSelectionContext()
-  if (!selectionContext) return
-
-  const quoted = extractQuote(selectionContext, true, options)
-  if (!quoted) return
-
-  transfer.setData('text/plain', selectionContext.text)
-  transfer.setData('text/x-gfm', quoted.selectionText)
-  event.preventDefault()
-
-  const selection = window.getSelection()
-  if (!selection) return
-  selection.removeAllRanges()
-  selection.addRange(selectionContext.range)
 }
 
 export function findContainer(el: Element): Element | undefined {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,6 @@ const containers: WeakMap<Element, Options> = new WeakMap()
 type Options = {
   quoteMarkdown: boolean
   scopeSelector: string
-  signal?: AbortSignal
 }
 
 interface SelectionContext {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import {extractFragment, insertMarkdownSyntax} from './markdown'
 
-const containers: WeakMap<Element, Options> = new WeakMap()
+const containers: WeakSet<Element> = new WeakSet()
 
 type Options = {
   quoteMarkdown: boolean
@@ -22,16 +22,8 @@ export function getSelectionContext(): SelectionContext | null {
   }
 }
 
-export function install(container: Element, options?: Partial<Options>) {
-  const config: Options = Object.assign(
-    {
-      quoteMarkdown: false,
-      copyMarkdown: false,
-      scopeSelector: ''
-    },
-    options
-  )
-  containers.set(container, config)
+export function install(container: Element) {
+  containers.add(container)
 }
 
 export function findContainer(el: Element): Element | undefined {

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import {install, getSelectionContext, quote} from '../dist/index.js'
+import {getSelectionContext, quote} from '../dist/index.js'
 
 function createSelection(selection, el) {
   const range = document.createRange()
@@ -22,8 +22,6 @@ describe('quote-selection', function () {
           <textarea id="not-hidden-textarea">Has text</textarea>
         </div>
       `
-      install(document.querySelector('[data-quote]'))
-      install(document.querySelector('[data-nested-quote]'))
     })
 
     afterEach(function () {
@@ -48,7 +46,7 @@ describe('quote-selection', function () {
         changeCount++
       })
 
-      quote(getSelectionContext())
+      quote(getSelectionContext(), {containerSelector: '[data-quote], [data-nested-quote]'})
       assert.equal(textarea.value, 'Has text\n\n> Test Quotable text, bold.\n\n')
       assert.equal(eventCount, 1)
       assert.equal(changeCount, 1)
@@ -66,7 +64,7 @@ describe('quote-selection', function () {
         textarea.hidden = false
       })
 
-      quote(getSelectionContext())
+      quote(getSelectionContext(), {containerSelector: '[data-quote], [data-nested-quote]'})
       assert.equal(outerTextarea.value, 'Has text')
       assert.equal(textarea.value, 'Has text\n\n> Nested text.\n\n')
     })
@@ -77,7 +75,7 @@ describe('quote-selection', function () {
       window.getSelection = () => createSelection(selection, el)
 
       const textarea = document.querySelector('#not-hidden-textarea')
-      quote(getSelectionContext())
+      quote(getSelectionContext(), {containerSelector: '[data-quote], [data-nested-quote]'})
       assert.equal(textarea.value, 'Has text')
     })
   })
@@ -100,7 +98,6 @@ describe('quote-selection', function () {
           <textarea></textarea>
         </div>
       `
-      install(document.querySelector('[data-quote]'))
     })
 
     afterEach(function () {
@@ -115,7 +112,8 @@ describe('quote-selection', function () {
           {text: 'whatever', range},
           {
             quoteMarkdown: true,
-            scopeSelector: '.comment-body'
+            scopeSelector: '.comment-body',
+            containerSelector: '[data-quote]'
           }
         )
       )
@@ -155,7 +153,8 @@ describe('quote-selection', function () {
           {text: 'whatever', range},
           {
             quoteMarkdown: true,
-            scopeSelector: '.comment-body'
+            scopeSelector: '.comment-body',
+            containerSelector: '[data-quote]'
           }
         )
       )

--- a/test/test.js
+++ b/test/test.js
@@ -10,8 +10,6 @@ function createSelection(selection, el) {
 
 describe('quote-selection', function () {
   describe('with quotable selection', function () {
-    let controller
-
     beforeEach(function () {
       document.body.innerHTML = `
         <p id="not-quotable">Not quotable text</p>
@@ -24,14 +22,11 @@ describe('quote-selection', function () {
           <textarea id="not-hidden-textarea">Has text</textarea>
         </div>
       `
-      controller = new AbortController()
-
-      install(document.querySelector('[data-quote]'), {signal: controller.signal})
-      install(document.querySelector('[data-nested-quote]'), {signal: controller.signal})
+      install(document.querySelector('[data-quote]'))
+      install(document.querySelector('[data-nested-quote]'))
     })
 
     afterEach(function () {
-      controller.abort()
       document.body.innerHTML = ''
     })
 
@@ -88,7 +83,6 @@ describe('quote-selection', function () {
   })
 
   describe('with markdown enabled', function () {
-    let controller
     beforeEach(function () {
       document.body.innerHTML = `
         <div data-quote>
@@ -106,16 +100,10 @@ describe('quote-selection', function () {
           <textarea></textarea>
         </div>
       `
-      controller = new AbortController()
-      install(document.querySelector('[data-quote]'), {
-        quoteMarkdown: true,
-        scopeSelector: '.comment-body',
-        signal: controller.signal
-      })
+      install(document.querySelector('[data-quote]'))
     })
 
     afterEach(function () {
-      controller.abort()
       document.body.innerHTML = ''
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -131,10 +131,13 @@ describe('quote-selection', function () {
       const range = document.createRange()
       range.selectNodeContents(document.querySelector('.comment-body').parentNode)
       assert.ok(
-        quote('whatever', range, {
-          quoteMarkdown: true,
-          scopeSelector: '.comment-body'
-        })
+        quote(
+          {text: 'whatever', range},
+          {
+            quoteMarkdown: true,
+            scopeSelector: '.comment-body'
+          }
+        )
       )
 
       const textarea = document.querySelector('textarea')
@@ -168,10 +171,13 @@ describe('quote-selection', function () {
       const range = document.createRange()
       range.selectNodeContents(document.querySelector('.comment-body').parentNode)
       assert.ok(
-        quote('whatever', range, {
-          quoteMarkdown: true,
-          scopeSelector: '.comment-body'
-        })
+        quote(
+          {text: 'whatever', range},
+          {
+            quoteMarkdown: true,
+            scopeSelector: '.comment-body'
+          }
+        )
       )
 
       const textarea = document.querySelector('textarea')

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import {install, quote} from '../dist/index.js'
+import {install, getSelectionContext, quote} from '../dist/index.js'
 
 function createSelection(selection, el) {
   const range = document.createRange()
@@ -6,14 +6,6 @@ function createSelection(selection, el) {
   selection.removeAllRanges()
   selection.addRange(range)
   return selection
-}
-
-function quoteShortcut() {
-  document.dispatchEvent(
-    new KeyboardEvent('keydown', {
-      key: 'r'
-    })
-  )
 }
 
 describe('quote-selection', function () {
@@ -61,7 +53,7 @@ describe('quote-selection', function () {
         changeCount++
       })
 
-      quoteShortcut()
+      quote(getSelectionContext())
       assert.equal(textarea.value, 'Has text\n\n> Test Quotable text, bold.\n\n')
       assert.equal(eventCount, 1)
       assert.equal(changeCount, 1)
@@ -79,7 +71,7 @@ describe('quote-selection', function () {
         textarea.hidden = false
       })
 
-      quoteShortcut()
+      quote(getSelectionContext())
       assert.equal(outerTextarea.value, 'Has text')
       assert.equal(textarea.value, 'Has text\n\n> Nested text.\n\n')
     })
@@ -90,7 +82,7 @@ describe('quote-selection', function () {
       window.getSelection = () => createSelection(selection, el)
 
       const textarea = document.querySelector('#not-hidden-textarea')
-      quoteShortcut()
+      quote(getSelectionContext())
       assert.equal(textarea.value, 'Has text')
     })
   })


### PR DESCRIPTION
## What?

Following from #29 this is a further refactoring that removes the event binding that we do (the `r` shortcut and `copy` event), instead opting to document those as patterns. This allows us to _remove_ the AbortController that we added in #29 because instead we can simply delete the `install()` method, opting for this library to be called imperatively however we want to upstream.

## Why?

This offers good separation of concerns: this library is mainly tasked with converting HTML to a markdown quote, and shouldn't _also_ be concerned with event management. To quote the commits:

> The code for handling event listening is very trivial, and might vary per consumer of this library. It is not core functionality, and should be left to upstream to setup.

> Removing this reduces the API surface area and complexity from this library as it doesn't need to concern itself with event management and keyboard shortcuts.
