### PR TITLE
Refactor codebase to use classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import {extractQuote, insertQuote} from '@github/quote-selection'
 
 document.addEventListener('keydown', event => {
   if (event.key == 'r') {
-    const quote = extractQuote({containerSelector: '.my-quote-region'})
+    const quote = extractQuote('.my-quote-region')
     if (quote) {
       insertQuote(quote.selectionText, document.querySelector('textarea'))
     }

--- a/README.md
+++ b/README.md
@@ -52,13 +52,10 @@ The optional `scopeSelector` parameter of `MarkdownQuote` ensures that even if t
 ## Development
 
 ```
-
 npm install
 npm test
-
 ```
 
 ## License
 
 Distributed under the MIT license. See LICENSE for details.
-```

--- a/README.md
+++ b/README.md
@@ -18,21 +18,26 @@ $ npm install @github/quote-selection
 ```
 
 ```js
-import {getSelectionContext, quote} from '@github/quote-selection'
+import {getSelectionContext, extractQuote, insertQuote} from '@github/quote-selection'
 
 document.addEventListener('keydown', event => {
   if (event.key == 'r') {
-    quote(getSelectionContext(), { containerSelector: '.my-quote-region' })
+    const quote = extractQuote(getSelectionContext(), {containerSelector: '.my-quote-region'})
+    if (quote) {
+      insertQuote(quote.selectionText, document.querySelector('textarea'))
+    }
   }
 })
 ```
 
-Calling `quote` with `getSelectionContext` will take the currently selected HTML, converts it to markdown, and appends the quoted representation of the selected text into the first applicable `<textarea>` element.
+`extractQuote` will take the currently selected HTML from the specified quote region, convert it to markdown, and create a quoted representation of the selection.
+
+`insertQuote` will insert the string representation of a selected text into the specified text area field.
 
 ### Preserving Markdown syntax
 
 ```js
-quote(getSelectionContext(), {
+extractQuote(getSelectionContext(), {
   quoteMarkdown: true,
   scopeSelector: '.comment-body',
   containerSelector: '.my-quote-region'
@@ -50,10 +55,13 @@ The optional `scopeSelector` parameter ensures that even if the user selection b
 ## Development
 
 ```
+
 npm install
 npm test
+
 ```
 
 ## License
 
 Distributed under the MIT license. See LICENSE for details.
+```

--- a/README.md
+++ b/README.md
@@ -44,21 +44,7 @@ The optional `scopeSelector` parameter ensures that even if the user selection b
 ## Events
 
 - `quote-selection-markdown` (bubbles: true, cancelable: false) - fired on the quote region to optionally inject custom syntax into the `fragment` element in `quoteMarkdown: true` mode
-- `quote-selection` (bubbles: true, cancelable: true) - fired on the quote region before text is appended to a textarea
 
-For example, reveal a textarea so it can be found:
-
-```js
-region.addEventListener('quote-selection', function (event) {
-  const {selection, selectionText} = event.detail
-  console.log('Quoted text', selection, selectionText)
-
-  const textarea = event.target.querySelector('textarea')
-  textarea.hidden = false
-
-  // Cancel the quote behavior.
-  // event.preventDefault()
-})
 ```
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -37,18 +37,13 @@ document.addEventListener('keydown', event => {
 ### Preserving Markdown syntax
 
 ```js
-extractQuote({
-  quoteMarkdown: true,
-  scopeSelector: '.comment-body',
-  containerSelector: '.my-quote-region'
-})
+const quote = extractQuote('.my-quote-region', document.querySelector('.comment-body'))
+const markdownQuote = asMarkdown(quote, '.comment-body')
 ```
 
-The optional `scopeSelector` parameter ensures that even if the user selection bleeds outside of the scoped element, the quoted portion will always be contained inside the scope. This is useful to avoid accidentally quoting parts of the UI that might be interspersed between quotable content.
+Calling `asMarkdown` on the `Quote` output of `extractQuote` will ensure markdown syntax is preserved.
 
-## Events
-
-- `quote-selection-markdown` (bubbles: true, cancelable: false) - fired on the quote region to optionally inject custom syntax into the `fragment` element in `quoteMarkdown: true` mode
+The optional `scopeSelector` parameter of `asMarkdown` ensures that even if the user selection bleeds outside of the scoped element, the quoted portion will always be contained inside the scope. This is useful to avoid accidentally quoting parts of the UI that might be interspersed between quotable content.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ $ npm install @github/quote-selection
 ```
 
 ```js
-import {Quote, insertQuote} from '@github/quote-selection'
+import {Quote} from '@github/quote-selection'
 
 document.addEventListener('keydown', event => {
   if (event.key == 'r') {
     const quote = new Quote()
     if (quote && quote.container('.my-quote-region')) {
-      insertQuote(quote, document.querySelector('textarea'))
+      quote.insert(document.querySelector('textarea'))
     }
   }
 })
@@ -32,7 +32,7 @@ document.addEventListener('keydown', event => {
 
 `Quote` will take the currently selected HTML from the specified quote region, convert it to markdown, and create a quoted representation of the selection.
 
-`insertQuote` will insert the string representation of a selected text into the specified text area field.
+`insert` will insert the string representation of a selected text into the specified text area field.
 
 ### Preserving Markdown syntax
 
@@ -40,7 +40,7 @@ document.addEventListener('keydown', event => {
 const quote = new MarkdownQuote(window.getSelection(), '.comment-body')
 quote.select(document.querySelector('.comment-body'))
 if (quote.container('.my-quote-region')) {
-  insertQuote(quote, document.querySelector('textarea'))
+  quote.insert(quote, document.querySelector('textarea'))
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Using `MarkdownQuote` instead of `Quote` will ensure markdown syntax is preserve
 
 The optional `scopeSelector` parameter of `MarkdownQuote` ensures that even if the user selection bleeds outside of the scoped element, the quoted portion will always be contained inside the scope. This is useful to avoid accidentally quoting parts of the UI that might be interspersed between quotable content.
 
-```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ import {Quote} from '@github/quote-selection'
 document.addEventListener('keydown', event => {
   if (event.key == 'r') {
     const quote = new Quote()
-    if (quote && quote.container('.my-quote-region')) {
+    if (quote.closest('.my-quote-region')) {
       quote.insert(document.querySelector('textarea'))
     }
   }
@@ -39,7 +39,7 @@ document.addEventListener('keydown', event => {
 ```js
 const quote = new MarkdownQuote('.comment-body')
 quote.select(document.querySelector('.comment-body'))
-if (quote.container('.my-quote-region')) {
+if (quote.closest('.my-quote-region')) {
   quote.insert(quote, document.querySelector('textarea'))
 }
 ```

--- a/README.md
+++ b/README.md
@@ -37,16 +37,16 @@ document.addEventListener('keydown', event => {
 ### Preserving Markdown syntax
 
 ```js
-const quote = new Quote()
+const quote = new MarkdownQuote(window.getSelection(), '.comment-body')
 quote.select(document.querySelector('.comment-body'))
 if (quote.container('.my-quote-region')) {
-  const markdownQuote = asMarkdown(quote, '.comment-body')
+  insertQuote(quote, document.querySelector('textarea'))
 }
 ```
 
-Calling `asMarkdown` on the `Quote` will ensure markdown syntax is preserved.
+Using `MarkdownQuote` instead of `Quote` will ensure markdown syntax is preserved.
 
-The optional `scopeSelector` parameter of `asMarkdown` ensures that even if the user selection bleeds outside of the scoped element, the quoted portion will always be contained inside the scope. This is useful to avoid accidentally quoting parts of the UI that might be interspersed between quotable content.
+The optional `scopeSelector` parameter of `MarkdownQuote` ensures that even if the user selection bleeds outside of the scoped element, the quoted portion will always be contained inside the scope. This is useful to avoid accidentally quoting parts of the UI that might be interspersed between quotable content.
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ document.addEventListener('keydown', event => {
   if (event.key == 'r') {
     const quote = extractQuote('.my-quote-region')
     if (quote) {
-      insertQuote(quote.selectionText, document.querySelector('textarea'))
+      insertQuote(quote, document.querySelector('textarea'))
     }
   }
 })

--- a/README.md
+++ b/README.md
@@ -18,11 +18,11 @@ $ npm install @github/quote-selection
 ```
 
 ```js
-import {getSelectionContext, extractQuote, insertQuote} from '@github/quote-selection'
+import {extractQuote, insertQuote} from '@github/quote-selection'
 
 document.addEventListener('keydown', event => {
   if (event.key == 'r') {
-    const quote = extractQuote(getSelectionContext(), {containerSelector: '.my-quote-region'})
+    const quote = extractQuote({containerSelector: '.my-quote-region'})
     if (quote) {
       insertQuote(quote.selectionText, document.querySelector('textarea'))
     }
@@ -37,7 +37,7 @@ document.addEventListener('keydown', event => {
 ### Preserving Markdown syntax
 
 ```js
-extractQuote(getSelectionContext(), {
+extractQuote({
   quoteMarkdown: true,
   scopeSelector: '.comment-body',
   containerSelector: '.my-quote-region'

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ document.addEventListener('keydown', event => {
 ### Preserving Markdown syntax
 
 ```js
-const quote = new MarkdownQuote(window.getSelection(), '.comment-body')
+const quote = new MarkdownQuote('.comment-body')
 quote.select(document.querySelector('.comment-body'))
 if (quote.container('.my-quote-region')) {
   quote.insert(quote, document.querySelector('textarea'))

--- a/README.md
+++ b/README.md
@@ -18,30 +18,33 @@ $ npm install @github/quote-selection
 ```
 
 ```js
-import {extractQuote, insertQuote} from '@github/quote-selection'
+import {Quote, insertQuote} from '@github/quote-selection'
 
 document.addEventListener('keydown', event => {
   if (event.key == 'r') {
-    const quote = extractQuote('.my-quote-region')
-    if (quote) {
+    const quote = new Quote()
+    if (quote && quote.container('.my-quote-region')) {
       insertQuote(quote, document.querySelector('textarea'))
     }
   }
 })
 ```
 
-`extractQuote` will take the currently selected HTML from the specified quote region, convert it to markdown, and create a quoted representation of the selection.
+`Quote` will take the currently selected HTML from the specified quote region, convert it to markdown, and create a quoted representation of the selection.
 
 `insertQuote` will insert the string representation of a selected text into the specified text area field.
 
 ### Preserving Markdown syntax
 
 ```js
-const quote = extractQuote('.my-quote-region', document.querySelector('.comment-body'))
-const markdownQuote = asMarkdown(quote, '.comment-body')
+const quote = new Quote()
+quote.select(document.querySelector('.comment-body'))
+if (quote.container('.my-quote-region')) {
+  const markdownQuote = asMarkdown(quote, '.comment-body')
+}
 ```
 
-Calling `asMarkdown` on the `Quote` output of `extractQuote` will ensure markdown syntax is preserved.
+Calling `asMarkdown` on the `Quote` will ensure markdown syntax is preserved.
 
 The optional `scopeSelector` parameter of `asMarkdown` ensures that even if the user selection bleeds outside of the scoped element, the quoted portion will always be contained inside the scope. This is useful to avoid accidentally quoting parts of the UI that might be interspersed between quotable content.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,6 @@ import {extractFragment, insertMarkdownSyntax} from './markdown'
 type Options = {
   quoteMarkdown: boolean
   scopeSelector: string
-  containerSelector: string
   quoteElement: Element
 }
 
@@ -12,7 +11,7 @@ type Quote = {
   selectionText: string
 }
 
-export function extractQuote(options: Partial<Options>): Quote | undefined {
+export function extractQuote(containerSelector: string, options?: Partial<Options>): Quote | undefined {
   const selection = window.getSelection()
   if (!selection) return
   if (options?.quoteElement) {
@@ -28,15 +27,11 @@ export function extractQuote(options: Partial<Options>): Quote | undefined {
   let selectionText = selection.toString().trim()
   if (!selectionText) return
 
-  let focusNode: Node | null = range.startContainer
-  if (!focusNode) return
+  const focusNode = range.startContainer
+  const focusElement: Element | null = focusNode instanceof Element ? focusNode : focusNode.parentElement
+  if (!focusElement) return
 
-  if (focusNode.nodeType !== Node.ELEMENT_NODE) focusNode = focusNode.parentNode
-  if (!(focusNode instanceof Element)) return
-
-  if (!options?.containerSelector) return
-
-  const container = focusNode.closest(options.containerSelector)
+  const container = focusElement.closest(containerSelector)
   if (!container) return
 
   if (options?.quoteMarkdown) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,13 @@ export class Quote {
   get quotedText(): string {
     return `> ${this.selectionText.replace(/\n/g, '\n> ')}\n\n`
   }
+
+  select(element: Element) {
+    if (this.selection) {
+      this.selection.removeAllRanges()
+      this.selection.selectAllChildren(element)
+    }
+  }
 }
 
 export class MarkdownQuote extends Quote {
@@ -45,10 +52,7 @@ export class MarkdownQuote extends Quote {
 
 export function extractQuote(containerSelector: string, quoteElement?: Element): Quote {
   const quote = new Quote()
-  if (quote.selection && quoteElement) {
-    quote.selection.removeAllRanges()
-    quote.selection.selectAllChildren(quoteElement)
-  }
+  if (quoteElement) quote.select(quoteElement)
   return quote
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,24 +38,16 @@ export function extractQuote(containerSelector: string, options?: Partial<Option
   return {selectionText, range, container}
 }
 
-export function asMarkdown(quote: Quote, scopeSelector?: string): Quote | undefined {
-  try {
-    const fragment = extractFragment(quote.range, scopeSelector ?? '')
-    quote.container.dispatchEvent(
-      new CustomEvent('quote-selection-markdown', {
-        bubbles: true,
-        cancelable: false,
-        detail: {fragment, range: quote.range}
-      })
-    )
-    insertMarkdownSyntax(fragment)
-    quote.selectionText = selectFragment(fragment).replace(/^\n+/, '').replace(/\s+$/, '')
-    return quote
-  } catch (error) {
-    setTimeout(() => {
-      throw error
-    })
-  }
+export function asMarkdown(
+  quote: Quote,
+  scopeSelector?: string,
+  callback?: (fragment: DocumentFragment) => void
+): Quote | undefined {
+  const fragment = extractFragment(quote.range, scopeSelector ?? '')
+  callback?.(fragment)
+  insertMarkdownSyntax(fragment)
+  quote.selectionText = selectFragment(fragment).replace(/^\n+/, '').replace(/\s+$/, '')
+  return quote
 }
 
 export function insertQuote(selectionText: string, field: HTMLTextAreaElement) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,11 +27,11 @@ export function extractQuote(containerSelector: string, options?: Partial<Option
   let selectionText = selection.toString().trim()
   if (!selectionText) return
 
-  const focusNode = range.startContainer
-  const focusElement: Element | null = focusNode instanceof Element ? focusNode : focusNode.parentElement
-  if (!focusElement) return
+  const startContainer = range.startContainer
+  const startElement: Element | null = startContainer instanceof Element ? startContainer : startContainer.parentElement
+  if (!startElement) return
 
-  const container = focusElement.closest(containerSelector)
+  const container = startElement.closest(containerSelector)
   if (!container) return
 
   if (options?.quoteMarkdown) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,23 +1,17 @@
 import {extractFragment, insertMarkdownSyntax} from './markdown'
 
-type Options = {
-  quoteMarkdown: boolean
-  scopeSelector: string
-  quoteElement: Element
-}
-
 type Quote = {
   container: Element
   range: Range
   selectionText: string
 }
 
-export function extractQuote(containerSelector: string, options?: Partial<Options>): Quote | undefined {
+export function extractQuote(containerSelector: string, quoteElement?: Element): Quote | undefined {
   const selection = window.getSelection()
   if (!selection) return
-  if (options?.quoteElement) {
+  if (quoteElement) {
     selection.removeAllRanges()
-    selection.selectAllChildren(options.quoteElement)
+    selection.selectAllChildren(quoteElement)
   }
   let range
   try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,9 +53,9 @@ export class Quote {
 
 export class MarkdownQuote extends Quote {
   constructor(
-    public selection = window.getSelection(),
-    private scopeSelector?: string,
-    private callback?: (fragment: DocumentFragment) => void
+    private scopeSelector = '',
+    private callback?: (fragment: DocumentFragment) => void,
+    public selection = window.getSelection()
   ) {
     super(selection)
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,33 +1,39 @@
 import {extractFragment, insertMarkdownSyntax} from './markdown'
 
 export type Quote = {
-  container: Element
+  container: Element | null
   range: Range
   selectionText: string
   quotedText: string
 }
 
-export function extractQuote(containerSelector: string, quoteElement?: Element): Quote | undefined {
+export function extractQuote(containerSelector: string, quoteElement?: Element): Quote {
   const selection = window.getSelection()
-  if (!selection) return
+  const quote: Quote = {
+    container: null,
+    range: new Range(),
+    selectionText: '',
+    quotedText: ''
+  }
+  if (!selection) return quote
   if (quoteElement) {
     selection.removeAllRanges()
     selection.selectAllChildren(quoteElement)
   }
-  if (selection.rangeCount === 0) return
-  const range = selection.getRangeAt(0)
-  const selectionText = selection.toString().trim()
-  const quotedText = `> ${selectionText.replace(/\n/g, '\n> ')}\n\n`
-  if (!selectionText) return
+  if (selection.rangeCount === 0) return quote
+  quote.range = selection.getRangeAt(0)
+  quote.selectionText = selection.toString().trim()
+  quote.quotedText = `> ${quote.selectionText.replace(/\n/g, '\n> ')}\n\n`
+  if (!quote.selectionText) return quote
 
-  const startContainer = range.startContainer
+  const startContainer = quote.range.startContainer
   const startElement: Element | null = startContainer instanceof Element ? startContainer : startContainer.parentElement
-  if (!startElement) return
+  if (!startElement) return quote
 
-  const container = startElement.closest(containerSelector)
-  if (!container) return
+  quote.container = startElement.closest(containerSelector)
+  if (!quote.container) return quote
 
-  return {selectionText, quotedText, range, container}
+  return quote
 }
 
 export function asMarkdown(

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export function extractQuote(containerSelector: string, quoteElement?: Element):
   if (selection.rangeCount === 0) return
   const range = selection.getRangeAt(0)
   const selectionText = selection.toString().trim()
+  const quotedText = `> ${selectionText.replace(/\n/g, '\n> ')}\n\n`
   if (!selectionText) return
 
   const startContainer = range.startContainer
@@ -25,8 +26,6 @@ export function extractQuote(containerSelector: string, quoteElement?: Element):
 
   const container = startElement.closest(containerSelector)
   if (!container) return
-
-  const quotedText = `> ${selectionText.replace(/\n/g, '\n> ')}\n\n`
 
   return {selectionText, quotedText, range, container}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 import {extractFragment, insertMarkdownSyntax} from './markdown'
 
 export class Quote {
-  constructor(public selection = window.getSelection()) {}
+  selection = window.getSelection()
 
   container(selector: string): Element | null {
     const startContainer = this.range.startContainer
@@ -52,12 +52,8 @@ export class Quote {
 }
 
 export class MarkdownQuote extends Quote {
-  constructor(
-    private scopeSelector = '',
-    private callback?: (fragment: DocumentFragment) => void,
-    public selection = window.getSelection()
-  ) {
-    super(selection)
+  constructor(private scopeSelector = '', private callback?: (fragment: DocumentFragment) => void) {
+    super()
   }
 
   get selectionText() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,12 +50,6 @@ export class MarkdownQuote extends Quote {
   }
 }
 
-export function extractQuote(containerSelector: string, quoteElement?: Element): Quote {
-  const quote = new Quote()
-  if (quoteElement) quote.select(quoteElement)
-  return quote
-}
-
 export function asMarkdown(
   quote: Quote,
   scopeSelector?: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,23 @@ export class Quote {
   }
 }
 
+export class MarkdownQuote extends Quote {
+  constructor(
+    public selection = window.getSelection(),
+    private scopeSelector?: string,
+    private callback?: (fragment: DocumentFragment) => void
+  ) {
+    super(selection)
+  }
+
+  get selectionText() {
+    const fragment = extractFragment(this.range, this.scopeSelector ?? '')
+    this.callback?.(fragment)
+    insertMarkdownSyntax(fragment)
+    return selectFragment(fragment).replace(/^\n+/, '').replace(/\s+$/, '')
+  }
+}
+
 export function extractQuote(containerSelector: string, quoteElement?: Element): Quote {
   const quote = new Quote()
   if (quote.selection && quoteElement) {
@@ -40,17 +57,7 @@ export function asMarkdown(
   scopeSelector?: string,
   callback?: (fragment: DocumentFragment) => void
 ): Quote {
-  return new (class extends Quote {
-    constructor() {
-      super(quote.selection)
-    }
-    get selectionText() {
-      const fragment = extractFragment(this.range, scopeSelector ?? '')
-      callback?.(fragment)
-      insertMarkdownSyntax(fragment)
-      return selectFragment(fragment).replace(/^\n+/, '').replace(/\s+$/, '')
-    }
-  })()
+  return new MarkdownQuote(quote.selection, scopeSelector, callback)
 }
 
 export function insertQuote(quote: Quote, field: HTMLTextAreaElement) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,8 +44,8 @@ export function asMarkdown(
   return quote
 }
 
-export function insertQuote(selectionText: string, field: HTMLTextAreaElement) {
-  let quotedText = `> ${selectionText.replace(/\n/g, '\n> ')}\n\n`
+export function insertQuote(quote: Quote, field: HTMLTextAreaElement) {
+  let quotedText = `> ${quote.selectionText.replace(/\n/g, '\n> ')}\n\n`
   if (field.value) {
     quotedText = `${field.value}\n\n${quotedText}`
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,7 @@ export function asMarkdown(
   quote: Quote,
   scopeSelector?: string,
   callback?: (fragment: DocumentFragment) => void
-): Quote | undefined {
+): Quote {
   const fragment = extractFragment(quote.range, scopeSelector ?? '')
   callback?.(fragment)
   insertMarkdownSyntax(fragment)

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import {extractFragment, insertMarkdownSyntax} from './markdown'
 export class Quote {
   selection = window.getSelection()
 
-  container(selector: string): Element | null {
+  closest(selector: string): Element | null {
     const startContainer = this.range.startContainer
     const startElement: Element | null =
       startContainer instanceof Element ? startContainer : startContainer.parentElement

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ type Quote = {
   container: Element
   range: Range
   selectionText: string
+  quotedText: string
 }
 
 export function extractQuote(containerSelector: string, quoteElement?: Element): Quote | undefined {
@@ -29,7 +30,9 @@ export function extractQuote(containerSelector: string, quoteElement?: Element):
   const container = startElement.closest(containerSelector)
   if (!container) return
 
-  return {selectionText, range, container}
+  const quotedText = `> ${selectionText.replace(/\n/g, '\n> ')}\n\n`
+
+  return {selectionText, quotedText, range, container}
 }
 
 export function asMarkdown(
@@ -40,16 +43,22 @@ export function asMarkdown(
   const fragment = extractFragment(quote.range, scopeSelector ?? '')
   callback?.(fragment)
   insertMarkdownSyntax(fragment)
-  quote.selectionText = selectFragment(fragment).replace(/^\n+/, '').replace(/\s+$/, '')
-  return quote
+  const selectionText = selectFragment(fragment).replace(/^\n+/, '').replace(/\s+$/, '')
+  return {
+    selectionText,
+    quotedText: `> ${selectionText.replace(/\n/g, '\n> ')}\n\n`,
+    range: quote.range,
+    container: quote.container
+  }
 }
 
 export function insertQuote(quote: Quote, field: HTMLTextAreaElement) {
-  let quotedText = `> ${quote.selectionText.replace(/\n/g, '\n> ')}\n\n`
   if (field.value) {
-    quotedText = `${field.value}\n\n${quotedText}`
+    field.value = `${field.value}\n\n${quote.quotedText}`
+  } else {
+    field.value = quote.quotedText
   }
-  field.value = quotedText
+
   field.dispatchEvent(
     new CustomEvent('change', {
       bubbles: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,24 @@ export class Quote {
       this.selection.selectAllChildren(element)
     }
   }
+
+  insert(field: HTMLTextAreaElement) {
+    if (field.value) {
+      field.value = `${field.value}\n\n${this.quotedText}`
+    } else {
+      field.value = this.quotedText
+    }
+
+    field.dispatchEvent(
+      new CustomEvent('change', {
+        bubbles: true,
+        cancelable: false
+      })
+    )
+    field.focus()
+    field.selectionStart = field.value.length
+    field.scrollTop = field.scrollHeight
+  }
 }
 
 export class MarkdownQuote extends Quote {
@@ -68,22 +86,4 @@ export class MarkdownQuote extends Quote {
     }
     return selectionText.trim()
   }
-}
-
-export function insertQuote(quote: Quote, field: HTMLTextAreaElement) {
-  if (field.value) {
-    field.value = `${field.value}\n\n${quote.quotedText}`
-  } else {
-    field.value = quote.quotedText
-  }
-
-  field.dispatchEvent(
-    new CustomEvent('change', {
-      bubbles: true,
-      cancelable: false
-    })
-  )
-  field.focus()
-  field.selectionStart = field.value.length
-  field.scrollTop = field.scrollHeight
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,12 +14,8 @@ export function extractQuote(containerSelector: string, quoteElement?: Element):
     selection.removeAllRanges()
     selection.selectAllChildren(quoteElement)
   }
-  let range
-  try {
-    range = selection.getRangeAt(0)
-  } catch {
-    return
-  }
+  if (selection.rangeCount === 0) return
+  const range = selection.getRangeAt(0)
   const selectionText = selection.toString().trim()
   if (!selectionText) return
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import {extractFragment, insertMarkdownSyntax} from './markdown'
 
-type Quote = {
+export type Quote = {
   container: Element
   range: Range
   selectionText: string

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,14 +50,6 @@ export class MarkdownQuote extends Quote {
   }
 }
 
-export function asMarkdown(
-  quote: Quote,
-  scopeSelector?: string,
-  callback?: (fragment: DocumentFragment) => void
-): Quote {
-  return new MarkdownQuote(quote.selection, scopeSelector, callback)
-}
-
 export function insertQuote(quote: Quote, field: HTMLTextAreaElement) {
   if (field.value) {
     field.value = `${field.value}\n\n${quote.quotedText}`

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,32 +21,12 @@ export function getSelectionContext(): SelectionContext | null {
   }
 }
 
-export function findTextarea(container: Element): HTMLTextAreaElement | undefined {
-  for (const field of container.querySelectorAll('textarea')) {
-    if (field instanceof HTMLTextAreaElement && visible(field)) {
-      return field
-    }
-  }
-}
-
-export function quote(selectionContext: SelectionContext, options: Partial<Options>): boolean {
-  const quoted = extractQuote(selectionContext, options)
-  if (!quoted) return false
-
-  const {container, selectionText} = quoted
-  const field = findTextarea(container)
-  if (!field) return false
-
-  insertQuote(selectionText, field)
-  return true
-}
-
 type Quote = {
   container: Element
   selectionText: string
 }
 
-function extractQuote(selectionContext: SelectionContext, options: Partial<Options>): Quote | undefined {
+export function extractQuote(selectionContext: SelectionContext, options: Partial<Options>): Quote | undefined {
   let selectionText = selectionContext.text.trim()
   if (!selectionText) return
 
@@ -83,7 +63,7 @@ function extractQuote(selectionContext: SelectionContext, options: Partial<Optio
   return {selectionText, container}
 }
 
-function insertQuote(selectionText: string, field: HTMLTextAreaElement) {
+export function insertQuote(selectionText: string, field: HTMLTextAreaElement) {
   let quotedText = `> ${selectionText.replace(/\n/g, '\n> ')}\n\n`
   if (field.value) {
     quotedText = `${field.value}\n\n${quotedText}`
@@ -98,10 +78,6 @@ function insertQuote(selectionText: string, field: HTMLTextAreaElement) {
   field.focus()
   field.selectionStart = field.value.length
   field.scrollTop = field.scrollHeight
-}
-
-function visible(el: HTMLElement): boolean {
-  return !(el.offsetWidth <= 0 && el.offsetHeight <= 0)
 }
 
 function selectFragment(fragment: DocumentFragment): string {

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,19 +34,6 @@ export function quote(selectionContext: SelectionContext, options: Partial<Optio
   if (!quoted) return false
 
   const {container, selectionText} = quoted
-
-  const dispatched = container.dispatchEvent(
-    new CustomEvent('quote-selection', {
-      bubbles: true,
-      cancelable: true,
-      detail: {range: selectionContext.range, selectionText}
-    })
-  )
-
-  if (!dispatched) {
-    return true
-  }
-
   const field = findTextarea(container)
   if (!field) return false
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,7 +30,7 @@ export function findTextarea(container: Element): HTMLTextAreaElement | undefine
 }
 
 export function quote(selectionContext: SelectionContext, options: Partial<Options>): boolean {
-  const quoted = extractQuote(selectionContext, false, options)
+  const quoted = extractQuote(selectionContext, options)
   if (!quoted) return false
 
   const {container, selectionText} = quoted
@@ -59,11 +59,7 @@ type Quote = {
   selectionText: string
 }
 
-function extractQuote(
-  selectionContext: SelectionContext,
-  unwrap: boolean,
-  options: Partial<Options>
-): Quote | undefined {
+function extractQuote(selectionContext: SelectionContext, options: Partial<Options>): Quote | undefined {
   let selectionText = selectionContext.text.trim()
   if (!selectionText) return
 
@@ -85,7 +81,7 @@ function extractQuote(
         new CustomEvent('quote-selection-markdown', {
           bubbles: true,
           cancelable: false,
-          detail: {fragment, range: selectionContext.range, unwrap}
+          detail: {fragment, range: selectionContext.range}
         })
       )
       insertMarkdownSyntax(fragment)

--- a/test/test.js
+++ b/test/test.js
@@ -126,17 +126,14 @@ describe('quote-selection', function () {
       )
     })
 
-    it('allows quote-selection-markdown event to prepare content', function () {
-      document.querySelector('[data-quote]').addEventListener('quote-selection-markdown', function (event) {
-        const {fragment} = event.detail
-        fragment.querySelector('a[href]').replaceWith('@links')
-        fragment.querySelector('img[alt]').replaceWith(':emoji:')
-      })
-
+    it('provides a callback to mutate markup', function () {
       const quote = extractQuote('[data-quote]', {
         quoteElement: document.querySelector('.comment-body')
       })
-      const markdownQuote = asMarkdown(quote, '.comment-body')
+      const markdownQuote = asMarkdown(quote, '.comment-body', fragment => {
+        fragment.querySelector('a[href]').replaceWith('@links')
+        fragment.querySelector('img[alt]').replaceWith(':emoji:')
+      })
 
       const textarea = document.querySelector('textarea')
       insertQuote(markdownQuote.selectionText, textarea)

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import {MarkdownQuote, Quote, insertQuote} from '../dist/index.js'
+import {MarkdownQuote, Quote} from '../dist/index.js'
 
 function createSelection(selection, el) {
   const range = document.createRange()
@@ -41,7 +41,7 @@ describe('quote-selection', function () {
       })
       const quote = new Quote()
       assert.ok(quote.container('[data-quote], [data-nested-quote]'))
-      insertQuote(quote, textarea)
+      quote.insert(textarea)
 
       assert.equal(textarea.value, 'Has text\n\n> Test Quotable text, bold.\n\n')
       assert.equal(changeCount, 1)
@@ -58,7 +58,7 @@ describe('quote-selection', function () {
 
       const quote = new Quote()
       assert.ok(quote.container('[data-quote], [data-nested-quote]'))
-      insertQuote(quote, textarea)
+      quote.insert(textarea)
 
       assert.equal(outerTextarea.value, 'Has text')
       assert.equal(textarea.value, 'Has text\n\n> Nested text.\n\n')
@@ -104,7 +104,7 @@ describe('quote-selection', function () {
       quote.select(document.querySelector('.comment-body'))
       assert.ok(quote.container('[data-quote]'))
       const textarea = document.querySelector('textarea')
-      insertQuote(quote, textarea)
+      quote.insert(textarea)
 
       assert.equal(
         textarea.value.replace(/ +\n/g, '\n'),
@@ -135,7 +135,7 @@ describe('quote-selection', function () {
       assert.ok(quote.container('[data-quote]'))
 
       const textarea = document.querySelector('textarea')
-      insertQuote(quote, textarea)
+      quote.insert(textarea)
 
       assert.match(textarea.value, /^> @links and :emoji: are preserved\./m)
     })

--- a/test/test.js
+++ b/test/test.js
@@ -98,9 +98,7 @@ describe('quote-selection', function () {
     })
 
     it('preserves formatting', function () {
-      const quote = extractQuote('[data-quote]', {
-        quoteElement: document.querySelector('.comment-body')
-      })
+      const quote = extractQuote('[data-quote]', document.querySelector('.comment-body'))
       const markdownQuote = asMarkdown(quote, '.comment-body')
 
       const textarea = document.querySelector('textarea')
@@ -127,9 +125,7 @@ describe('quote-selection', function () {
     })
 
     it('provides a callback to mutate markup', function () {
-      const quote = extractQuote('[data-quote]', {
-        quoteElement: document.querySelector('.comment-body')
-      })
+      const quote = extractQuote('[data-quote]', document.querySelector('.comment-body'))
       const markdownQuote = asMarkdown(quote, '.comment-body', fragment => {
         fragment.querySelector('a[href]').replaceWith('@links')
         fragment.querySelector('img[alt]').replaceWith(':emoji:')

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import {getSelectionContext, quote} from '../dist/index.js'
+import {getSelectionContext, extractQuote, insertQuote} from '../dist/index.js'
 
 function createSelection(selection, el) {
   const range = document.createRange()
@@ -39,8 +39,9 @@ describe('quote-selection', function () {
       textarea.addEventListener('change', function () {
         changeCount++
       })
+      const quote = extractQuote(getSelectionContext(), {containerSelector: '[data-quote], [data-nested-quote]'})
+      insertQuote(quote.selectionText, textarea)
 
-      quote(getSelectionContext(), {containerSelector: '[data-quote], [data-nested-quote]'})
       assert.equal(textarea.value, 'Has text\n\n> Test Quotable text, bold.\n\n')
       assert.equal(changeCount, 1)
     })
@@ -54,7 +55,9 @@ describe('quote-selection', function () {
 
       textarea.hidden = false
 
-      quote(getSelectionContext(), {containerSelector: '[data-quote], [data-nested-quote]'})
+      const quote = extractQuote(getSelectionContext(), {containerSelector: '[data-quote], [data-nested-quote]'})
+      insertQuote(quote.selectionText, textarea)
+
       assert.equal(outerTextarea.value, 'Has text')
       assert.equal(textarea.value, 'Has text\n\n> Nested text.\n\n')
     })
@@ -64,9 +67,9 @@ describe('quote-selection', function () {
       const selection = window.getSelection()
       window.getSelection = () => createSelection(selection, el)
 
-      const textarea = document.querySelector('#not-hidden-textarea')
-      quote(getSelectionContext(), {containerSelector: '[data-quote], [data-nested-quote]'})
-      assert.equal(textarea.value, 'Has text')
+      const quote = extractQuote(getSelectionContext(), {containerSelector: '[data-quote], [data-nested-quote]'})
+
+      assert.equal(quote, undefined)
     })
   })
 
@@ -97,18 +100,18 @@ describe('quote-selection', function () {
     it('preserves formatting', function () {
       const range = document.createRange()
       range.selectNodeContents(document.querySelector('.comment-body').parentNode)
-      assert.ok(
-        quote(
-          {text: 'whatever', range},
-          {
-            quoteMarkdown: true,
-            scopeSelector: '.comment-body',
-            containerSelector: '[data-quote]'
-          }
-        )
+      const quote = extractQuote(
+        {text: 'whatever', range},
+        {
+          quoteMarkdown: true,
+          scopeSelector: '.comment-body',
+          containerSelector: '[data-quote]'
+        }
       )
-
+      assert.ok(quote)
       const textarea = document.querySelector('textarea')
+      insertQuote(quote.selectionText, textarea)
+
       assert.equal(
         textarea.value.replace(/ +\n/g, '\n'),
         `> This is **beautifully** formatted _text_ that even has some \`inline code\`.
@@ -138,18 +141,19 @@ describe('quote-selection', function () {
 
       const range = document.createRange()
       range.selectNodeContents(document.querySelector('.comment-body').parentNode)
-      assert.ok(
-        quote(
-          {text: 'whatever', range},
-          {
-            quoteMarkdown: true,
-            scopeSelector: '.comment-body',
-            containerSelector: '[data-quote]'
-          }
-        )
+      const quote = extractQuote(
+        {text: 'whatever', range},
+        {
+          quoteMarkdown: true,
+          scopeSelector: '.comment-body',
+          containerSelector: '[data-quote]'
+        }
       )
+      assert.ok(quote)
 
       const textarea = document.querySelector('textarea')
+      insertQuote(quote.selectionText, textarea)
+
       assert.match(textarea.value, /^> @links and :emoji: are preserved\./m)
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import {asMarkdown, Quote, insertQuote} from '../dist/index.js'
+import {MarkdownQuote, Quote, insertQuote} from '../dist/index.js'
 
 function createSelection(selection, el) {
   const range = document.createRange()
@@ -100,13 +100,11 @@ describe('quote-selection', function () {
     })
 
     it('preserves formatting', function () {
-      const quote = new Quote()
+      const quote = new MarkdownQuote(window.getSelection(), '.comment-body')
       quote.select(document.querySelector('.comment-body'))
       assert.ok(quote.container('[data-quote]'))
-      const markdownQuote = asMarkdown(quote, '.comment-body')
-
       const textarea = document.querySelector('textarea')
-      insertQuote(markdownQuote, textarea)
+      insertQuote(quote, textarea)
 
       assert.equal(
         textarea.value.replace(/ +\n/g, '\n'),
@@ -129,16 +127,15 @@ describe('quote-selection', function () {
     })
 
     it('provides a callback to mutate markup', function () {
-      const quote = new Quote()
-      quote.select(document.querySelector('.comment-body'))
-      assert.ok(quote.container('[data-quote]'))
-      const markdownQuote = asMarkdown(quote, '.comment-body', fragment => {
+      const quote = new MarkdownQuote(window.getSelection(), '.comment-body', fragment => {
         fragment.querySelector('a[href]').replaceWith('@links')
         fragment.querySelector('img[alt]').replaceWith(':emoji:')
       })
+      quote.select(document.querySelector('.comment-body'))
+      assert.ok(quote.container('[data-quote]'))
 
       const textarea = document.querySelector('textarea')
-      insertQuote(markdownQuote, textarea)
+      insertQuote(quote, textarea)
 
       assert.match(textarea.value, /^> @links and :emoji: are preserved\./m)
     })

--- a/test/test.js
+++ b/test/test.js
@@ -33,14 +33,8 @@ describe('quote-selection', function () {
       const selection = window.getSelection()
       window.getSelection = () => createSelection(selection, el)
 
-      const container = document.querySelector('[data-quote]')
       const textarea = document.querySelector('#not-hidden-textarea')
-      let eventCount = 0
       let changeCount = 0
-
-      container.addEventListener('quote-selection', function () {
-        eventCount++
-      })
 
       textarea.addEventListener('change', function () {
         changeCount++
@@ -48,7 +42,6 @@ describe('quote-selection', function () {
 
       quote(getSelectionContext(), {containerSelector: '[data-quote], [data-nested-quote]'})
       assert.equal(textarea.value, 'Has text\n\n> Test Quotable text, bold.\n\n')
-      assert.equal(eventCount, 1)
       assert.equal(changeCount, 1)
     })
 
@@ -56,13 +49,10 @@ describe('quote-selection', function () {
       const el = document.querySelector('#nested-quotable')
       const selection = window.getSelection()
       window.getSelection = () => createSelection(selection, el)
-      const container = document.querySelector('[data-nested-quote]')
       const textarea = document.querySelector('#nested-textarea')
       const outerTextarea = document.querySelector('#not-hidden-textarea')
 
-      container.addEventListener('quote-selection', function () {
-        textarea.hidden = false
-      })
+      textarea.hidden = false
 
       quote(getSelectionContext(), {containerSelector: '[data-quote], [data-nested-quote]'})
       assert.equal(outerTextarea.value, 'Has text')

--- a/test/test.js
+++ b/test/test.js
@@ -100,7 +100,7 @@ describe('quote-selection', function () {
     })
 
     it('preserves formatting', function () {
-      const quote = new MarkdownQuote(window.getSelection(), '.comment-body')
+      const quote = new MarkdownQuote('.comment-body')
       quote.select(document.querySelector('.comment-body'))
       assert.ok(quote.container('[data-quote]'))
       const textarea = document.querySelector('textarea')
@@ -127,7 +127,7 @@ describe('quote-selection', function () {
     })
 
     it('provides a callback to mutate markup', function () {
-      const quote = new MarkdownQuote(window.getSelection(), '.comment-body', fragment => {
+      const quote = new MarkdownQuote('.comment-body', fragment => {
         fragment.querySelector('a[href]').replaceWith('@links')
         fragment.querySelector('img[alt]').replaceWith(':emoji:')
       })

--- a/test/test.js
+++ b/test/test.js
@@ -40,7 +40,7 @@ describe('quote-selection', function () {
         changeCount++
       })
       const quote = new Quote()
-      assert.ok(quote.container('[data-quote], [data-nested-quote]'))
+      assert.ok(quote.closest('[data-quote], [data-nested-quote]'))
       quote.insert(textarea)
 
       assert.equal(textarea.value, 'Has text\n\n> Test Quotable text, bold.\n\n')
@@ -57,7 +57,7 @@ describe('quote-selection', function () {
       textarea.hidden = false
 
       const quote = new Quote()
-      assert.ok(quote.container('[data-quote], [data-nested-quote]'))
+      assert.ok(quote.closest('[data-quote], [data-nested-quote]'))
       quote.insert(textarea)
 
       assert.equal(outerTextarea.value, 'Has text')
@@ -71,7 +71,7 @@ describe('quote-selection', function () {
 
       const quote = new Quote()
 
-      assert.equal(quote.container('[data-quote], [data-nested-quote]'), null)
+      assert.equal(quote.closest('[data-quote], [data-nested-quote]'), null)
     })
   })
 
@@ -102,7 +102,7 @@ describe('quote-selection', function () {
     it('preserves formatting', function () {
       const quote = new MarkdownQuote('.comment-body')
       quote.select(document.querySelector('.comment-body'))
-      assert.ok(quote.container('[data-quote]'))
+      assert.ok(quote.closest('[data-quote]'))
       const textarea = document.querySelector('textarea')
       quote.insert(textarea)
 
@@ -132,7 +132,7 @@ describe('quote-selection', function () {
         fragment.querySelector('img[alt]').replaceWith(':emoji:')
       })
       quote.select(document.querySelector('.comment-body'))
-      assert.ok(quote.container('[data-quote]'))
+      assert.ok(quote.closest('[data-quote]'))
 
       const textarea = document.querySelector('textarea')
       quote.insert(textarea)

--- a/test/test.js
+++ b/test/test.js
@@ -69,7 +69,7 @@ describe('quote-selection', function () {
 
       const quote = extractQuote('[data-quote], [data-nested-quote]')
 
-      assert.equal(quote.container, null)
+      assert.equal(quote.container('[data-quote], [data-nested-quote]'), null)
     })
   })
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import {extractQuote, insertQuote} from '../dist/index.js'
+import {asMarkdown, extractQuote, insertQuote} from '../dist/index.js'
 
 function createSelection(selection, el) {
   const range = document.createRange()
@@ -99,12 +99,12 @@ describe('quote-selection', function () {
 
     it('preserves formatting', function () {
       const quote = extractQuote('[data-quote]', {
-        quoteMarkdown: true,
-        scopeSelector: '.comment-body',
         quoteElement: document.querySelector('.comment-body')
       })
+      const markdownQuote = asMarkdown(quote, '.comment-body')
+
       const textarea = document.querySelector('textarea')
-      insertQuote(quote.selectionText, textarea)
+      insertQuote(markdownQuote.selectionText, textarea)
 
       assert.equal(
         textarea.value.replace(/ +\n/g, '\n'),
@@ -134,13 +134,12 @@ describe('quote-selection', function () {
       })
 
       const quote = extractQuote('[data-quote]', {
-        quoteMarkdown: true,
-        scopeSelector: '.comment-body',
         quoteElement: document.querySelector('.comment-body')
       })
+      const markdownQuote = asMarkdown(quote, '.comment-body')
 
       const textarea = document.querySelector('textarea')
-      insertQuote(quote.selectionText, textarea)
+      insertQuote(markdownQuote.selectionText, textarea)
 
       assert.match(textarea.value, /^> @links and :emoji: are preserved\./m)
     })

--- a/test/test.js
+++ b/test/test.js
@@ -39,7 +39,7 @@ describe('quote-selection', function () {
       textarea.addEventListener('change', function () {
         changeCount++
       })
-      const quote = extractQuote({containerSelector: '[data-quote], [data-nested-quote]'})
+      const quote = extractQuote('[data-quote], [data-nested-quote]')
       insertQuote(quote.selectionText, textarea)
 
       assert.equal(textarea.value, 'Has text\n\n> Test Quotable text, bold.\n\n')
@@ -55,7 +55,7 @@ describe('quote-selection', function () {
 
       textarea.hidden = false
 
-      const quote = extractQuote({containerSelector: '[data-quote], [data-nested-quote]'})
+      const quote = extractQuote('[data-quote], [data-nested-quote]')
       insertQuote(quote.selectionText, textarea)
 
       assert.equal(outerTextarea.value, 'Has text')
@@ -67,7 +67,7 @@ describe('quote-selection', function () {
       const selection = window.getSelection()
       window.getSelection = () => createSelection(selection, el)
 
-      const quote = extractQuote({containerSelector: '[data-quote], [data-nested-quote]'})
+      const quote = extractQuote('[data-quote], [data-nested-quote]')
 
       assert.equal(quote, undefined)
     })
@@ -98,10 +98,9 @@ describe('quote-selection', function () {
     })
 
     it('preserves formatting', function () {
-      const quote = extractQuote({
+      const quote = extractQuote('[data-quote]', {
         quoteMarkdown: true,
         scopeSelector: '.comment-body',
-        containerSelector: '[data-quote]',
         quoteElement: document.querySelector('.comment-body')
       })
       const textarea = document.querySelector('textarea')
@@ -134,10 +133,9 @@ describe('quote-selection', function () {
         fragment.querySelector('img[alt]').replaceWith(':emoji:')
       })
 
-      const quote = extractQuote({
+      const quote = extractQuote('[data-quote]', {
         quoteMarkdown: true,
         scopeSelector: '.comment-body',
-        containerSelector: '[data-quote]',
         quoteElement: document.querySelector('.comment-body')
       })
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import {asMarkdown, extractQuote, insertQuote} from '../dist/index.js'
+import {asMarkdown, Quote, insertQuote} from '../dist/index.js'
 
 function createSelection(selection, el) {
   const range = document.createRange()
@@ -39,7 +39,8 @@ describe('quote-selection', function () {
       textarea.addEventListener('change', function () {
         changeCount++
       })
-      const quote = extractQuote('[data-quote], [data-nested-quote]')
+      const quote = new Quote()
+      assert.ok(quote.container('[data-quote], [data-nested-quote]'))
       insertQuote(quote, textarea)
 
       assert.equal(textarea.value, 'Has text\n\n> Test Quotable text, bold.\n\n')
@@ -55,7 +56,8 @@ describe('quote-selection', function () {
 
       textarea.hidden = false
 
-      const quote = extractQuote('[data-quote], [data-nested-quote]')
+      const quote = new Quote()
+      assert.ok(quote.container('[data-quote], [data-nested-quote]'))
       insertQuote(quote, textarea)
 
       assert.equal(outerTextarea.value, 'Has text')
@@ -67,7 +69,7 @@ describe('quote-selection', function () {
       const selection = window.getSelection()
       window.getSelection = () => createSelection(selection, el)
 
-      const quote = extractQuote('[data-quote], [data-nested-quote]')
+      const quote = new Quote()
 
       assert.equal(quote.container('[data-quote], [data-nested-quote]'), null)
     })
@@ -98,7 +100,9 @@ describe('quote-selection', function () {
     })
 
     it('preserves formatting', function () {
-      const quote = extractQuote('[data-quote]', document.querySelector('.comment-body'))
+      const quote = new Quote()
+      quote.select(document.querySelector('.comment-body'))
+      assert.ok(quote.container('[data-quote]'))
       const markdownQuote = asMarkdown(quote, '.comment-body')
 
       const textarea = document.querySelector('textarea')
@@ -125,7 +129,9 @@ describe('quote-selection', function () {
     })
 
     it('provides a callback to mutate markup', function () {
-      const quote = extractQuote('[data-quote]', document.querySelector('.comment-body'))
+      const quote = new Quote()
+      quote.select(document.querySelector('.comment-body'))
+      assert.ok(quote.container('[data-quote]'))
       const markdownQuote = asMarkdown(quote, '.comment-body', fragment => {
         fragment.querySelector('a[href]').replaceWith('@links')
         fragment.querySelector('img[alt]').replaceWith(':emoji:')

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,4 @@
-import {getSelectionContext, extractQuote, insertQuote} from '../dist/index.js'
+import {extractQuote, insertQuote} from '../dist/index.js'
 
 function createSelection(selection, el) {
   const range = document.createRange()
@@ -39,7 +39,7 @@ describe('quote-selection', function () {
       textarea.addEventListener('change', function () {
         changeCount++
       })
-      const quote = extractQuote(getSelectionContext(), {containerSelector: '[data-quote], [data-nested-quote]'})
+      const quote = extractQuote({containerSelector: '[data-quote], [data-nested-quote]'})
       insertQuote(quote.selectionText, textarea)
 
       assert.equal(textarea.value, 'Has text\n\n> Test Quotable text, bold.\n\n')
@@ -55,7 +55,7 @@ describe('quote-selection', function () {
 
       textarea.hidden = false
 
-      const quote = extractQuote(getSelectionContext(), {containerSelector: '[data-quote], [data-nested-quote]'})
+      const quote = extractQuote({containerSelector: '[data-quote], [data-nested-quote]'})
       insertQuote(quote.selectionText, textarea)
 
       assert.equal(outerTextarea.value, 'Has text')
@@ -67,7 +67,7 @@ describe('quote-selection', function () {
       const selection = window.getSelection()
       window.getSelection = () => createSelection(selection, el)
 
-      const quote = extractQuote(getSelectionContext(), {containerSelector: '[data-quote], [data-nested-quote]'})
+      const quote = extractQuote({containerSelector: '[data-quote], [data-nested-quote]'})
 
       assert.equal(quote, undefined)
     })
@@ -98,17 +98,12 @@ describe('quote-selection', function () {
     })
 
     it('preserves formatting', function () {
-      const range = document.createRange()
-      range.selectNodeContents(document.querySelector('.comment-body').parentNode)
-      const quote = extractQuote(
-        {text: 'whatever', range},
-        {
-          quoteMarkdown: true,
-          scopeSelector: '.comment-body',
-          containerSelector: '[data-quote]'
-        }
-      )
-      assert.ok(quote)
+      const quote = extractQuote({
+        quoteMarkdown: true,
+        scopeSelector: '.comment-body',
+        containerSelector: '[data-quote]',
+        quoteElement: document.querySelector('.comment-body')
+      })
       const textarea = document.querySelector('textarea')
       insertQuote(quote.selectionText, textarea)
 
@@ -139,17 +134,12 @@ describe('quote-selection', function () {
         fragment.querySelector('img[alt]').replaceWith(':emoji:')
       })
 
-      const range = document.createRange()
-      range.selectNodeContents(document.querySelector('.comment-body').parentNode)
-      const quote = extractQuote(
-        {text: 'whatever', range},
-        {
-          quoteMarkdown: true,
-          scopeSelector: '.comment-body',
-          containerSelector: '[data-quote]'
-        }
-      )
-      assert.ok(quote)
+      const quote = extractQuote({
+        quoteMarkdown: true,
+        scopeSelector: '.comment-body',
+        containerSelector: '[data-quote]',
+        quoteElement: document.querySelector('.comment-body')
+      })
 
       const textarea = document.querySelector('textarea')
       insertQuote(quote.selectionText, textarea)

--- a/test/test.js
+++ b/test/test.js
@@ -40,7 +40,7 @@ describe('quote-selection', function () {
         changeCount++
       })
       const quote = extractQuote('[data-quote], [data-nested-quote]')
-      insertQuote(quote.selectionText, textarea)
+      insertQuote(quote, textarea)
 
       assert.equal(textarea.value, 'Has text\n\n> Test Quotable text, bold.\n\n')
       assert.equal(changeCount, 1)
@@ -56,7 +56,7 @@ describe('quote-selection', function () {
       textarea.hidden = false
 
       const quote = extractQuote('[data-quote], [data-nested-quote]')
-      insertQuote(quote.selectionText, textarea)
+      insertQuote(quote, textarea)
 
       assert.equal(outerTextarea.value, 'Has text')
       assert.equal(textarea.value, 'Has text\n\n> Nested text.\n\n')
@@ -102,7 +102,7 @@ describe('quote-selection', function () {
       const markdownQuote = asMarkdown(quote, '.comment-body')
 
       const textarea = document.querySelector('textarea')
-      insertQuote(markdownQuote.selectionText, textarea)
+      insertQuote(markdownQuote, textarea)
 
       assert.equal(
         textarea.value.replace(/ +\n/g, '\n'),
@@ -132,7 +132,7 @@ describe('quote-selection', function () {
       })
 
       const textarea = document.querySelector('textarea')
-      insertQuote(markdownQuote.selectionText, textarea)
+      insertQuote(markdownQuote, textarea)
 
       assert.match(textarea.value, /^> @links and :emoji: are preserved\./m)
     })

--- a/test/test.js
+++ b/test/test.js
@@ -69,7 +69,7 @@ describe('quote-selection', function () {
 
       const quote = extractQuote('[data-quote], [data-nested-quote]')
 
-      assert.equal(quote, undefined)
+      assert.equal(quote.container, null)
     })
   })
 


### PR DESCRIPTION
This is quite a large change, but building from the work of #29 and #30 we can crystalise the core behaviours of this method to be a `Quote` class, which is really a wrapper around browsers' built-in `Selection` class, but does some extra stuff.

This is a radical change from the existing code, but it is much simpler (as evidenced by the README), and will simplify upstream code quite considerably.