### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
         id: new-tag
         run: |
           version=$(jq -r .version < package.json)
-          echo "::set-output name=new-tag::v$version"
+          echo "new-tag=v$version" >> $GITHUB_OUTPUT
   create-release:
     name: Create GitHub release
     runs-on: ubuntu-latest


### PR DESCRIPTION
`save-state` and `set-output` commands [used in GitHub Actions are deprecated](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `set-output` to `$GITHUB_OUTPUT`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter


