### PR TITLE
Add optional process func for selection text

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,10 @@
 import {extractFragment, insertMarkdownSyntax} from './markdown'
 
+type ProcessSelectionTextFn = (str: string) => string
+
 export class Quote {
   selection = window.getSelection()
+  processSelectionText: ProcessSelectionTextFn = (str) => str
 
   closest(selector: string): Element | null {
     const startContainer = this.range.startContainer
@@ -25,8 +28,12 @@ export class Quote {
     this.selection?.addRange(range)
   }
 
+  set processSelectionTextFn(fn: ProcessSelectionTextFn) {
+    this.processSelectionText = fn
+  }
+
   get selectionText(): string {
-    return this.selection?.toString().trim() || ''
+    return this.processSelectionText(this.selection?.toString().trim() || '')
   }
 
   get quotedText(): string {
@@ -91,6 +98,6 @@ export class MarkdownQuote extends Quote {
     } finally {
       body.removeChild(div)
     }
-    return selectionText.trim()
+    return this.processSelectionText(selectionText.trim())
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ type ProcessSelectionTextFn = (str: string) => string
 
 export class Quote {
   selection = window.getSelection()
-  processSelectionText: ProcessSelectionTextFn = (str) => str
+  processSelectionText: ProcessSelectionTextFn = str => str
 
   closest(selector: string): Element | null {
     const startContainer = this.range.startContainer

--- a/test/test.js
+++ b/test/test.js
@@ -101,6 +101,20 @@ describe('quote-selection', function () {
 
       assert.equal(textarea.value, 'Has text\n\n> bold\n\n')
     })
+
+    it('allows processing the quoted text before inserting it', function () {
+      const el = document.querySelector('#quotable')
+      const selection = window.getSelection()
+      window.getSelection = () => createSelection(selection, el)
+
+      const textarea = document.querySelector('#not-hidden-textarea')
+      const quote = new Quote()
+      quote.processSelectionTextFn = text => text.replace('Quotable', 'replaced')
+
+      quote.insert(textarea)
+
+      assert.equal(textarea.value, 'Has text\n\n> Test replaced text, bold.\n\n')
+    })
   })
 
   describe('with markdown enabled', function () {


### PR DESCRIPTION
Adding this optional passed in processing function for the selection text before it is inserted back into the dom. This allows for doing things like search and replace if we need to.
 
This is done to address [an issue](https://github.com/github/issues/issues/10490) we have where quoted assets are entered into the new comment with the short lived JWT. Since we already have the asset with the camo'd url on the client, this can be solved with a simple search and replace before we enter the quoted text into the dom.

Since this is an opt-in behaviour, it should not affect any existing consumers.



